### PR TITLE
Add grootfs init-store and delete-store to tests

### DIFF
--- a/cell/cell_suite_test.go
+++ b/cell/cell_suite_test.go
@@ -62,7 +62,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	componentMaker = helpers.MakeComponentMaker(builtArtifacts, localIP)
+	Expect(componentMaker.GrootfsInitStores()).To(Succeed())
 })
+
+var _ = SynchronizedAfterSuite(func() {
+	Expect(componentMaker.GrootfsDeleteStores()).To(Succeed())
+}, func() {})
 
 var _ = BeforeEach(func() {
 	plumbing = ginkgomon.Invoke(grouper.NewParallel(os.Kill, grouper.Members{

--- a/executor/executor_suite_test.go
+++ b/executor/executor_suite_test.go
@@ -42,7 +42,13 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	componentMaker = helpers.MakeComponentMaker(builtArtifacts, localIP)
+
+	Expect(componentMaker.GrootfsInitStores()).To(Succeed())
 })
+
+var _ = SynchronizedAfterSuite(func() {
+	Expect(componentMaker.GrootfsDeleteStores()).To(Succeed())
+}, func() {})
 
 var _ = BeforeEach(func() {
 	gardenProcess = ginkgomon.Invoke(componentMaker.Garden())

--- a/helpers/construct_world.go
+++ b/helpers/construct_world.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"code.cloudfoundry.org/bbs/test_helpers"
 	"code.cloudfoundry.org/consuladapter/consulrunner"
@@ -129,8 +130,9 @@ func MakeComponentMaker(builtArtifacts world.BuiltArtifacts, localIP string) wor
 		CACert:     caCert,
 	}
 
+	storeTimestamp := time.Now().UnixNano
 	unprivilegedGrootfsConfig := world.GrootFSConfig{
-		StorePath: fmt.Sprintf("/mnt/btrfs/unprivileged-%d", ginkgo.GinkgoParallelNode()),
+		StorePath: fmt.Sprintf("/mnt/btrfs/unprivileged-%d-%d", ginkgo.GinkgoParallelNode(), storeTimestamp),
 		DraxBin:   "/usr/local/bin/drax",
 		LogLevel:  "debug",
 	}
@@ -138,7 +140,7 @@ func MakeComponentMaker(builtArtifacts world.BuiltArtifacts, localIP string) wor
 	unprivilegedGrootfsConfig.Create.GidMappings = []string{"0:4294967294:1", "1:1:4294967293"}
 
 	privilegedGrootfsConfig := world.GrootFSConfig{
-		StorePath: fmt.Sprintf("/mnt/btrfs/privileged-%d", ginkgo.GinkgoParallelNode()),
+		StorePath: fmt.Sprintf("/mnt/btrfs/privileged-%d-%d", ginkgo.GinkgoParallelNode(), storeTimestamp),
 		DraxBin:   "/usr/local/bin/drax",
 		LogLevel:  "debug",
 	}

--- a/volman/volman_suite_test.go
+++ b/volman/volman_suite_test.go
@@ -62,7 +62,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	componentMaker = helpers.MakeComponentMaker(builtArtifacts, localIP)
+	Expect(componentMaker.GrootfsInitStores()).To(Succeed())
 })
+
+var _ = SynchronizedAfterSuite(func() {
+	Expect(componentMaker.GrootfsDeleteStores()).To(Succeed())
+}, func() {})
 
 var _ = BeforeEach(func() {
 	logger = lagertest.NewTestLogger("volman-inigo-suite")


### PR DESCRIPTION
* `grootfs init-store` is the correct way to initialize a store for grootfs. At this moment it doesn't do much, but to avoid breaking changes in the future is good to be sure it's getting called before the tests run.
* `grootfs delete-store` is a store "de-initializer", that should take care in the future for cleaning up any mounts left behind.