### PR TITLE
Upgrade to go-loggregator v2.0.0

### DIFF
--- a/executor/executor_garden_test.go
+++ b/executor/executor_garden_test.go
@@ -15,7 +15,7 @@ import (
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/gardenhealth"
 	executorinit "code.cloudfoundry.org/executor/initializer"
-	"code.cloudfoundry.org/go-loggregator/loggregator_v2"
+	loggregator_v2 "code.cloudfoundry.org/go-loggregator"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
@@ -78,7 +78,7 @@ var _ = Describe("Executor/Garden", func() {
 
 		logger = lagertest.NewTestLogger("test")
 		var executorMembers grouper.Members
-		metronClient, err := loggregator_v2.NewClient(logger, loggregator_v2.MetronConfig{})
+		metronClient, err := loggregator_v2.NewClient(loggregator_v2.Config{})
 		Expect(err).NotTo(HaveOccurred())
 
 		executorClient, executorMembers, err = executorinit.Initialize(logger, config, gardenHealthcheckRootFS, metronClient, clock.NewClock())

--- a/volman/volman_executor_test.go
+++ b/volman/volman_executor_test.go
@@ -16,12 +16,12 @@ import (
 	"code.cloudfoundry.org/durationjson"
 	"code.cloudfoundry.org/executor"
 	executorinit "code.cloudfoundry.org/executor/initializer"
+	loggregator_v2 "code.cloudfoundry.org/go-loggregator"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/voldriver"
 	"code.cloudfoundry.org/voldriver/driverhttp"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
-	"code.cloudfoundry.org/go-loggregator/loggregator_v2"
 	. "github.com/onsi/ginkgo"
 	ginkgoconfig "github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
@@ -344,7 +344,7 @@ func initializeExecutor(logger lager.Logger, config executorinit.ExecutorConfig)
 	var err error
 	var executorClient executor.Client
 	defaultRootFS := ""
-	metronClient, err := loggregator_v2.NewClient(logger, loggregator_v2.MetronConfig{})
+	metronClient, err := loggregator_v2.NewClient(loggregator_v2.Config{})
 	Expect(err).NotTo(HaveOccurred())
 	executorClient, executorMembers, err = executorinit.Initialize(logger, config, defaultRootFS, metronClient, clock.NewClock())
 	Expect(err).NotTo(HaveOccurred())

--- a/world/components.go
+++ b/world/components.go
@@ -33,7 +33,7 @@ import (
 	"code.cloudfoundry.org/garden"
 	gardenclient "code.cloudfoundry.org/garden/client"
 	gardenconnection "code.cloudfoundry.org/garden/client/connection"
-	"code.cloudfoundry.org/go-loggregator/loggregator_v2"
+	loggregator_v2 "code.cloudfoundry.org/go-loggregator"
 	gorouterconfig "code.cloudfoundry.org/gorouter/config"
 	"code.cloudfoundry.org/guardian/gqt/runner"
 	"code.cloudfoundry.org/lager"
@@ -804,7 +804,7 @@ func (maker ComponentMaker) VolmanClient(logger lager.Logger) (volman.Manager, i
 	driverConfig := volmanclient.NewDriverConfig()
 	driverConfig.DriverPaths = []string{path.Join(maker.VolmanDriverConfigDir, fmt.Sprintf("node-%d", config.GinkgoConfig.ParallelNode))}
 
-	metronClient, err := loggregator_v2.NewClient(logger, loggregator_v2.MetronConfig{})
+	metronClient, err := loggregator_v2.NewClient(loggregator_v2.Config{})
 	Expect(err).NotTo(HaveOccurred())
 	return volmanclient.NewServer(logger, metronClient, driverConfig)
 }


### PR DESCRIPTION
Note that this PR is meant to go hand-in-hand with the following PRs:
- https://github.com/cloudfoundry/executor/pull/26
- https://github.com/cloudfoundry/rep/pull/14
- https://github.com/cloudfoundry/volman/pull/2
- https://github.com/cloudfoundry/diego-release/pull/308

/cc @bradylove