### PR TITLE
Use diego logging client in place of compatibility

### DIFF
--- a/executor/executor_garden_test.go
+++ b/executor/executor_garden_test.go
@@ -11,11 +11,11 @@ import (
 
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/clock"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/durationjson"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/gardenhealth"
 	executorinit "code.cloudfoundry.org/executor/initializer"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
@@ -78,7 +78,7 @@ var _ = Describe("Executor/Garden", func() {
 
 		logger = lagertest.NewTestLogger("test")
 		var executorMembers grouper.Members
-		metronClient, err := loggregator_v2.NewIngressClient(loggregator_v2.Config{})
+		metronClient, err := loggingclient.NewIngressClient(loggingclient.Config{})
 		Expect(err).NotTo(HaveOccurred())
 
 		executorClient, executorMembers, err = executorinit.Initialize(logger, config, gardenHealthcheckRootFS, metronClient, clock.NewClock())

--- a/volman/volman_executor_test.go
+++ b/volman/volman_executor_test.go
@@ -13,10 +13,10 @@ import (
 
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/clock"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/durationjson"
 	"code.cloudfoundry.org/executor"
 	executorinit "code.cloudfoundry.org/executor/initializer"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/voldriver"
@@ -344,7 +344,7 @@ func initializeExecutor(logger lager.Logger, config executorinit.ExecutorConfig)
 	var err error
 	var executorClient executor.Client
 	defaultRootFS := ""
-	metronClient, err := loggregator_v2.NewIngressClient(loggregator_v2.Config{})
+	metronClient, err := loggingclient.NewIngressClient(loggingclient.Config{})
 	Expect(err).NotTo(HaveOccurred())
 	executorClient, executorMembers, err = executorinit.Initialize(logger, config, defaultRootFS, metronClient, clock.NewClock())
 	Expect(err).NotTo(HaveOccurred())

--- a/world/components.go
+++ b/world/components.go
@@ -26,6 +26,7 @@ import (
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/consuladapter"
 	"code.cloudfoundry.org/consuladapter/consulrunner"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	sshproxyconfig "code.cloudfoundry.org/diego-ssh/cmd/ssh-proxy/config"
 	"code.cloudfoundry.org/durationjson"
 	executorinit "code.cloudfoundry.org/executor/initializer"
@@ -33,7 +34,6 @@ import (
 	"code.cloudfoundry.org/garden"
 	gardenclient "code.cloudfoundry.org/garden/client"
 	gardenconnection "code.cloudfoundry.org/garden/client/connection"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/guardian/gqt/runner"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerflags"
@@ -901,7 +901,7 @@ func (maker ComponentMaker) VolmanClient(logger lager.Logger) (volman.Manager, i
 	driverConfig := volmanclient.NewDriverConfig()
 	driverConfig.DriverPaths = []string{path.Join(maker.VolmanDriverConfigDir, fmt.Sprintf("node-%d", config.GinkgoConfig.ParallelNode))}
 
-	metronClient, err := loggregator_v2.NewIngressClient(loggregator_v2.Config{})
+	metronClient, err := loggingclient.NewIngressClient(loggingclient.Config{})
 	Expect(err).NotTo(HaveOccurred())
 	return volmanclient.NewServer(logger, metronClient, driverConfig)
 }


### PR DESCRIPTION
This work upgrades Diego to use go-loggregator v3.0.0. It also encapsulates Diego's use of the loggregator client behind a single interface found in `diego-logging-client` within `diego-release`.

By wrapping go-loggregator in Diego, we ensure future upgrades to go-loggregator will not require such large change sets.

This PR goes hand in hand with the following PRs:
- [diego-release](https://github.com/cloudfoundry/diego-release/pull/349)
- [auctioneer](https://github.com/cloudfoundry/auctioneer/pull/6)
- [bbs](https://github.com/cloudfoundry/bbs/pull/24)
- [benchmarkbbs](https://github.com/cloudfoundry/benchmarkbbs/pull/3)
- [locket](https://github.com/cloudfoundry/locket/pull/3)
- [rep](https://github.com/cloudfoundry/rep/pull/17)
- [executor](https://github.com/cloudfoundry/executor/pull/27)
- [volman](https://github.com/cloudfoundry/volman/pull/4)

[#148451433]

Signed-off-by: Jason Keene <jkeene@pivotal.io>