### PR TITLE
Update for dockerdriver repo rename (ne voldriver)

### DIFF
--- a/volman/volman_executor_test.go
+++ b/volman/volman_executor_test.go
@@ -14,6 +14,9 @@ import (
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/clock"
 	loggingclient "code.cloudfoundry.org/diego-logging-client"
+	"code.cloudfoundry.org/dockerdriver"
+	"code.cloudfoundry.org/dockerdriver/driverhttp"
+	dockerdriverutils "code.cloudfoundry.org/dockerdriver/utils"
 	"code.cloudfoundry.org/durationjson"
 	"code.cloudfoundry.org/executor"
 	executorinit "code.cloudfoundry.org/executor/initializer"
@@ -21,9 +24,6 @@ import (
 	"code.cloudfoundry.org/inigo/world"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
-	"code.cloudfoundry.org/voldriver"
-	"code.cloudfoundry.org/voldriver/driverhttp"
-	voldriverutils "code.cloudfoundry.org/voldriver/utils"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
 	. "github.com/onsi/ginkgo"
 	ginkgoconfig "github.com/onsi/ginkgo/config"
@@ -42,7 +42,7 @@ var _ = Describe("Executor/Garden/Volman", func() {
 		cachePath      string
 		config         executorinit.ExecutorConfig
 		logger         lager.Logger
-		env            voldriver.Env
+		env            dockerdriver.Env
 		err            error
 	)
 
@@ -130,14 +130,14 @@ var _ = Describe("Executor/Garden/Volman", func() {
 
 		Context("when there are volumes", func() {
 			BeforeEach(func() {
-				uniqueVolumeId := voldriverutils.NewVolumeId("a-volume", "a-container")
-				errorResponse := driverClient.Create(env, voldriver.CreateRequest{
+				uniqueVolumeId := dockerdriverutils.NewVolumeId("a-volume", "a-container")
+				errorResponse := driverClient.Create(env, dockerdriver.CreateRequest{
 					Name: uniqueVolumeId.GetUniqueId(),
 					Opts: map[string]interface{}{},
 				})
 				Expect(errorResponse.Err).To(BeEmpty())
 
-				mountResponse := driverClient.Mount(env, voldriver.MountRequest{
+				mountResponse := driverClient.Mount(env, dockerdriver.MountRequest{
 					Name: uniqueVolumeId.GetUniqueId(),
 				})
 				Expect(mountResponse.Err).To(BeEmpty())
@@ -282,7 +282,7 @@ var _ = Describe("Executor/Garden/Volman", func() {
 					BeforeEach(func() {
 						fileName = fmt.Sprintf("testfile-%d.txt", time.Now().UnixNano())
 						volumeId = fmt.Sprintf("some-volumeID-%d", time.Now().UnixNano())
-						uniqueVolumeId := voldriverutils.NewVolumeId(volumeId, guid)
+						uniqueVolumeId := dockerdriverutils.NewVolumeId(volumeId, guid)
 						volumeDirectoryName = uniqueVolumeId.GetUniqueId()
 						someConfig := map[string]interface{}{"volume_id": volumeId}
 						volumeMounts = []executor.VolumeMount{executor.VolumeMount{ContainerPath: "/testmount", Driver: "localdriver", VolumeId: volumeId, Config: someConfig, Mode: executor.BindMountModeRW}}

--- a/volman/volman_suite_test.go
+++ b/volman/volman_suite_test.go
@@ -11,6 +11,7 @@ import (
 
 	"code.cloudfoundry.org/consuladapter/consulrunner"
 	"code.cloudfoundry.org/csiplugin"
+	"code.cloudfoundry.org/dockerdriver"
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/inigo/helpers"
 	"code.cloudfoundry.org/inigo/helpers/portauthority"
@@ -19,7 +20,6 @@ import (
 	"code.cloudfoundry.org/lager/ginkgoreporter"
 	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/localip"
-	"code.cloudfoundry.org/voldriver"
 	"code.cloudfoundry.org/volman"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
@@ -43,7 +43,7 @@ var (
 	localDriverProcess     ifrit.Process
 	localNodePluginProcess ifrit.Process
 
-	driverClient    voldriver.Driver
+	driverClient    dockerdriver.Driver
 	localNodeClient volman.Plugin
 
 	logger lager.Logger
@@ -118,7 +118,7 @@ var _ = BeforeEach(func() {
 
 	// make a dummy spec file not corresponding to a running driver just to make sure volman ignores it
 	driverPluginsPath = path.Join(componentMaker.VolmanDriverConfigDir(), fmt.Sprintf("node-%d", config.GinkgoConfig.ParallelNode))
-	voldriver.WriteDriverSpec(logger, driverPluginsPath, "deaddriver", "json", []byte(`{"Name":"deaddriver","Addr":"https://127.0.0.1:1111"}`))
+	dockerdriver.WriteDriverSpec(logger, driverPluginsPath, "deaddriver", "json", []byte(`{"Name":"deaddriver","Addr":"https://127.0.0.1:1111"}`))
 
 	// make a dummy spec file not corresponding to a running node plugin just to make sure volman ignores it
 	csiPluginsPath = path.Join(componentMaker.VolmanDriverConfigDir(), fmt.Sprintf("local-node-plugin-%d", config.GinkgoConfig.ParallelNode))

--- a/volman/volman_test.go
+++ b/volman/volman_test.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"path"
 
+	dockerdriverutils "code.cloudfoundry.org/dockerdriver/utils"
 	"code.cloudfoundry.org/inigo/helpers"
 	"code.cloudfoundry.org/localdriver"
-	voldriverutils "code.cloudfoundry.org/voldriver/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/tedsuo/ifrit/ginkgomon"
@@ -55,7 +55,7 @@ var _ = Describe("Given volman and localdriver", func() {
 			expectedMountPath string
 		)
 		BeforeEach(func() {
-			uniqueVolumeId := voldriverutils.NewVolumeId(volumeId, containerId)
+			uniqueVolumeId := dockerdriverutils.NewVolumeId(volumeId, containerId)
 			expectedMountPath = path.Join(componentMaker.VolmanDriverConfigDir(), localdriver.MountsRootDir, uniqueVolumeId.GetUniqueId())
 		})
 


### PR DESCRIPTION
Hi Diego Team,

This PR updates inigo to work with the renamed voldriver repo, now called dockerdriver. See [our story](https://www.pivotaltracker.com/story/show/161637604) for more context. In addition to this change, you will also need to bump the following submodules of diego-release:

csiplugin: 67738772ab8a44e1ef597d9513fafa87289da8f9
localdriver: cf93a407cfe5dda6c1b36492f3c8b5293f013540
volman: 12b8148976fc2ef8f49849632989ef342a16a18d

You will also need to replace the old voldriver submodule with the new dockerdriver submodule. You can HEAD of master for this. All units and inigo/volman have passed. We assume that you have this in your `commit-with-submodule-logs` script, but you will need to resync the package specs due to the repo rename.

Let us know if you have any questions.

Regards,
Dave && @paulcwarren 