### PR TITLE
Fix: DesireLRP requires MetricTags to be non-nil

### DIFF
--- a/cell/instance_identity_test.go
+++ b/cell/instance_identity_test.go
@@ -114,7 +114,6 @@ var _ = Describe("InstanceIdentity", func() {
 			CacheKey:  "lrp-cache-key",
 			LogSource: "APP",
 		}}
-		lrp.MetricsGuid = processGUID
 		lrp.Ports = []uint32{8080, 8081}
 		lrp.Action = models.WrapAction(&models.RunAction{
 			User: "vcap",
@@ -822,7 +821,6 @@ var _ = Describe("InstanceIdentity", func() {
 							)
 
 							lrp = helpers.DockerLRPCreateRequest(componentMaker.Addresses(), processGUID)
-							lrp.MetricsGuid = processGUID
 							lrp.MemoryMb = int32(memoryLimit)
 						})
 
@@ -841,7 +839,6 @@ var _ = Describe("InstanceIdentity", func() {
 								Skip("TODO: use buildpack LRP. docker lrp is not supported on windows")
 							}
 							lrp = helpers.DockerLRPCreateRequest(componentMaker.Addresses(), processGUID)
-							lrp.MetricsGuid = processGUID
 							lrp.MemoryMb = int32(memoryLimit)
 						})
 

--- a/helpers/bbs_requests.go
+++ b/helpers/bbs_requests.go
@@ -91,6 +91,8 @@ func lrpCreateRequest(
 		Action:        action,
 		Monitor:       monitor,
 		PlacementTags: placementTags,
+
+		MetricTags: &map[string]*MetricTagValue{"source_id": {"static": processGuid}},
 	}
 }
 


### PR DESCRIPTION
## Please make sure to complete all of the following steps

1. Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests.
1. Submit your PR to this repo.
1. ~~[**Submit an accompanying PR Review Request**](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=pr-review-request.md&title=%5BINIGO+PR+REVIEW%5D%3A) referencing this PR so the Diego Team knows to review your pull request.~~
* ~~**Note: this PR will not be reviewed unless you submit the [PR Review Request](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=pr-review-request.md&title=%5BINIGO+PR+REVIEW%5D%3A)**.~~
Not submitting a separate PR Review Request as we already have https://github.com/cloudfoundry/diego-release/issues/662 as a central issue to link PRs to.

***************************

## Please provide the following information:

### What is this change about?

Updates Inigo tests to set MetricTags when desiring LRPs. Recent changes to BBS now require that MetricTags is non-nil when desiring an LRP.

Removes some use of MetricsGuid, which is deprecated.

### What problem it is trying to solve?

Fixes errors in Inigo related to recent BBS changes as part of the dynamic app log renaming work.

### What is the impact if the change is not made?

Inigo will consistently fail on newer versions of BBS.

### How should this change be described in diego-release release notes?

Metric tags can be updated on Desired LRPs. Logs and metrics emitted by a LRP will then use the updated metric tags.

### Please provide any contextual information.

https://ci.funtime.lol/teams/diego/pipelines/diego-release/jobs/inigo/builds/130

### Tag your pair, your PM, and/or team!

None

Thank you!
