### PR TITLE
Add test to validate trace id is being logged across Diego components

### DIFF
--- a/cell/cell_suite_test.go
+++ b/cell/cell_suite_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/durationjson"
+	"code.cloudfoundry.org/guardian/gqt/runner"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/localip"
 	. "github.com/onsi/ginkgo/v2"
@@ -37,6 +38,8 @@ var (
 	gardenClient                        garden.Client
 	bbsClient                           bbs.InternalClient
 	bbsServiceClient                    serviceclient.ServiceClient
+	bbsRunner                           *ginkgomon.Runner
+	gardenRunner                        *runner.GardenRunner
 	lgr                                 lager.Logger
 	suiteTempDir                        string
 )
@@ -121,8 +124,10 @@ var _ = BeforeEach(func() {
 		})},
 		{Name: "locket", Runner: componentMaker.Locket()},
 	}))
-	gardenProcess = ginkgomon.Invoke(componentMaker.Garden())
-	bbsProcess = ginkgomon.Invoke(componentMaker.BBS())
+	gardenRunner = componentMaker.Garden()
+	gardenProcess = ginkgomon.Invoke(gardenRunner)
+	bbsRunner = componentMaker.BBS()
+	bbsProcess = ginkgomon.Invoke(bbsRunner)
 
 	lgr = lager.NewLogger("test")
 	lgr.RegisterSink(lager.NewWriterSink(GinkgoWriter, lager.DEBUG))

--- a/cell/converger_test.go
+++ b/cell/converger_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Convergence to desired state", func() {
 				))
 
 				By("creating and ActualLRP")
-				err := bbsClient.DesireLRP(lgr, helpers.DefaultLRPCreateRequest(componentMaker.Addresses(), processGuid, appId, 2))
+				err := bbsClient.DesireLRP(lgr, "", helpers.DefaultLRPCreateRequest(componentMaker.Addresses(), processGuid, appId, 2))
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(runningLRPsPoller).Should(HaveLen(2))
 				Eventually(helloWorldInstancePoller).Should(Equal([]string{"0", "1"}))
@@ -170,7 +170,7 @@ var _ = Describe("Convergence to desired state", func() {
 
 			Context("and an LRP is desired", func() {
 				BeforeEach(func() {
-					err := bbsClient.DesireLRP(lgr, helpers.DefaultLRPCreateRequest(componentMaker.Addresses(), processGuid, appId, 1))
+					err := bbsClient.DesireLRP(lgr, "", helpers.DefaultLRPCreateRequest(componentMaker.Addresses(), processGuid, appId, 1))
 					Expect(err).NotTo(HaveOccurred())
 
 					Consistently(runningLRPsPoller).Should(BeEmpty())
@@ -207,7 +207,7 @@ var _ = Describe("Convergence to desired state", func() {
 
 			Context("and an LRP is desired", func() {
 				BeforeEach(func() {
-					err := bbsClient.DesireLRP(lgr, helpers.DefaultLRPCreateRequest(componentMaker.Addresses(), processGuid, appId, 1))
+					err := bbsClient.DesireLRP(lgr, "", helpers.DefaultLRPCreateRequest(componentMaker.Addresses(), processGuid, appId, 1))
 					Expect(err).NotTo(HaveOccurred())
 
 					Consistently(runningLRPsPoller).Should(BeEmpty())
@@ -234,7 +234,7 @@ var _ = Describe("Convergence to desired state", func() {
 
 			Context("and an LRP is desired", func() {
 				BeforeEach(func() {
-					err := bbsClient.DesireLRP(lgr, helpers.DefaultLRPCreateRequest(componentMaker.Addresses(), processGuid, appId, 1))
+					err := bbsClient.DesireLRP(lgr, "", helpers.DefaultLRPCreateRequest(componentMaker.Addresses(), processGuid, appId, 1))
 					Expect(err).NotTo(HaveOccurred())
 
 					Consistently(runningLRPsPoller).Should(BeEmpty())

--- a/cell/evacuation_test.go
+++ b/cell/evacuation_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Evacuation", func() {
 
 	It("handles evacuation", func() {
 		By("desiring an LRP")
-		err := bbsClient.DesireLRP(lgr, lrp)
+		err := bbsClient.DesireLRP(lgr, "", lrp)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("running an actual LRP instance")
@@ -142,7 +142,7 @@ var _ = Describe("Evacuation", func() {
 		Eventually(helpers.ResponseCodeFromHostPoller(componentMaker.Addresses().Router, helpers.DefaultHost)).Should(Equal(http.StatusOK))
 
 		index := int32(0)
-		lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid, Index: &index})
+		lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid, Index: &index})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(lrps)).To(Equal(1))
 		Expect(lrps[0].Presence).NotTo(Equal(models.ActualLRP_Evacuating))
@@ -201,7 +201,7 @@ var _ = Describe("Evacuation", func() {
 		It("shuts down gracefully after the evacuation timeout", func() {
 			time.Sleep(time.Minute)
 
-			err := bbsClient.DesireLRP(lgr, lrp)
+			err := bbsClient.DesireLRP(lgr, "", lrp)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("running an actual LRP instance")
@@ -218,11 +218,11 @@ var _ = Describe("Evacuation", func() {
 			addr := fmt.Sprintf("https://%s.cell.service.cf.internal:%d", cellAID, cellPortsStart)
 			secureAddr := fmt.Sprintf("https://%s.cell.service.cf.internal:%d", cellAID, cellPortsStart+1)
 			// NewClientFactory <<- tls
-			client, err := factory.CreateClient(addr, secureAddr)
+			client, err := factory.CreateClient(addr, secureAddr, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			index := int32(0)
-			lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: lrp.ProcessGuid, Index: &index, CellID: cellAID})
+			lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: lrp.ProcessGuid, Index: &index, CellID: cellAID})
 			Expect(err).NotTo(HaveOccurred())
 			// This list of LRPs can have one or both of an EVACUATING LRP and an ORDINARY LRP (if we
 			// happen to catch the BBS before it has transitioned the ORDINARY one to UNCLAIMED). We don't

--- a/cell/instance_identity_test.go
+++ b/cell/instance_identity_test.go
@@ -254,7 +254,7 @@ var _ = Describe("InstanceIdentity", func() {
 		var address, ipAddress string
 
 		JustBeforeEach(func() {
-			err := bbsClient.DesireLRP(lgr, lrp)
+			err := bbsClient.DesireLRP(lgr, "", lrp)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(helpers.LRPStatePoller(lgr, bbsClient, processGUID, nil)).Should(Equal(models.ActualLRPStateRunning))
 
@@ -280,7 +280,7 @@ var _ = Describe("InstanceIdentity", func() {
 		var address string
 
 		JustBeforeEach(func() {
-			err := bbsClient.DesireLRP(lgr, lrp)
+			err := bbsClient.DesireLRP(lgr, "", lrp)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(helpers.LRPStatePoller(lgr, bbsClient, processGUID, nil)).Should(Equal(models.ActualLRPStateRunning))
 
@@ -428,7 +428,7 @@ var _ = Describe("InstanceIdentity", func() {
 
 		Context("and the app starts successfully", func() {
 			JustBeforeEach(func() {
-				err := bbsClient.DesireLRP(lgr, lrp)
+				err := bbsClient.DesireLRP(lgr, "", lrp)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(helpers.LRPStatePoller(lgr, bbsClient, processGUID, nil)).Should(Equal(models.ActualLRPStateRunning))
 
@@ -641,7 +641,7 @@ var _ = Describe("InstanceIdentity", func() {
 					Context("and is killed", func() {
 						JustBeforeEach(func() {
 							Eventually(connect, 10*time.Second).Should(Succeed())
-							err := bbsClient.RemoveDesiredLRP(lgr, lrp.ProcessGuid)
+							err := bbsClient.RemoveDesiredLRP(lgr, "", lrp.ProcessGuid)
 							Expect(err).NotTo(HaveOccurred())
 						})
 
@@ -733,7 +733,7 @@ var _ = Describe("InstanceIdentity", func() {
 				JustBeforeEach(func() {
 					containerMutex.Lock()
 					defer containerMutex.Unlock()
-					actualLRPs, err := bbsClient.ActualLRPs(logger, models.ActualLRPFilter{ProcessGuid: processGUID})
+					actualLRPs, err := bbsClient.ActualLRPs(logger, "", models.ActualLRPFilter{ProcessGuid: processGUID})
 					Expect(err).NotTo(HaveOccurred())
 					actualLRP := actualLRPs[0]
 					container, err = gardenClient.Lookup(actualLRP.InstanceGuid)
@@ -877,7 +877,7 @@ var _ = Describe("InstanceIdentity", func() {
 			})
 
 			JustBeforeEach(func() {
-				err := bbsClient.DesireLRP(lgr, lrp)
+				err := bbsClient.DesireLRP(lgr, "", lrp)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -897,7 +897,7 @@ var _ = Describe("InstanceIdentity", func() {
 					It("crashes the lrp with a descriptive error", func() {
 						Eventually(func() *models.ActualLRP {
 							index := int32(0)
-							lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGUID, Index: &index})
+							lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGUID, Index: &index})
 							Expect(err).NotTo(HaveOccurred())
 							Expect(len(lrps)).To(Equal(1))
 							return lrps[0]
@@ -960,7 +960,7 @@ func memoryInBytes(memoryMb uint64) uint64 {
 
 func getContainerInternalAddress(client bbs.Client, processGuid string, port uint32, tls bool) string {
 	By("getting the internal ip address of the container")
-	lrps, err := client.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid})
+	lrps, err := client.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(lrps).To(HaveLen(1))
 	netInfo := lrps[0].ActualLRPNetInfo
@@ -1009,14 +1009,14 @@ func runTaskAndGetCommandOutput(command string, organizationalUnits []string) st
 	)
 	expectedTask.ResultFile = resultFile
 
-	err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+	err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 	Expect(err).NotTo(HaveOccurred())
 
 	var task *models.Task
 	Eventually(func() interface{} {
 		var err error
 
-		task, err = bbsClient.TaskByGuid(lgr, guid)
+		task, err = bbsClient.TaskByGuid(lgr, "", guid)
 		Expect(err).NotTo(HaveOccurred())
 
 		return task.State

--- a/cell/local_route_emitter_test.go
+++ b/cell/local_route_emitter_test.go
@@ -124,7 +124,7 @@ var _ = Describe("LocalRouteEmitter", func() {
 
 		JustBeforeEach(func() {
 			lrp.Instances = instances
-			err := bbsClient.DesireLRP(lgr, lrp)
+			err := bbsClient.DesireLRP(lgr, "", lrp)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(helpers.LRPStatePoller(lgr, bbsClient, processGuid, nil)).Should(Equal(models.ActualLRPStateRunning))
 		})
@@ -230,7 +230,7 @@ var _ = Describe("LocalRouteEmitter", func() {
 
 			Context("and the app is deleted", func() {
 				JustBeforeEach(func() {
-					err := bbsClient.RemoveDesiredLRP(lgr, processGuid)
+					err := bbsClient.RemoveDesiredLRP(lgr, "", processGuid)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -253,7 +253,7 @@ var _ = Describe("LocalRouteEmitter", func() {
 				})
 
 				JustBeforeEach(func() {
-					err := bbsClient.UpdateDesiredLRP(lgr, processGuid, desiredLRPUdate)
+					err := bbsClient.UpdateDesiredLRP(lgr, "", processGuid, desiredLRPUdate)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -312,7 +312,7 @@ var _ = Describe("LocalRouteEmitter", func() {
 			JustBeforeEach(func() {
 				dlu := &models.DesiredLRPUpdate{}
 				dlu.SetInstances(newInstances)
-				err := bbsClient.UpdateDesiredLRP(lgr, processGuid, dlu)
+				err := bbsClient.UpdateDesiredLRP(lgr, "", processGuid, dlu)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -383,7 +383,7 @@ func evacuateARep(
 	cellAPort, cellBPort uint16,
 ) {
 	By("finding rep with one instance running")
-	lrps, err := bbsClient.ActualLRPs(logger, models.ActualLRPFilter{ProcessGuid: processGuid})
+	lrps, err := bbsClient.ActualLRPs(logger, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(lrps).To(HaveLen(3))
 	instancePerRepCount := map[string]int{}

--- a/cell/long_running_healthchecks_test.go
+++ b/cell/long_running_healthchecks_test.go
@@ -152,7 +152,7 @@ var _ = Context("when declarative healthchecks is turned on", func() {
 		})
 
 		JustBeforeEach(func() {
-			err := bbsClient.DesireLRP(lgr, lrp)
+			err := bbsClient.DesireLRP(lgr, "", lrp)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -177,7 +177,7 @@ var _ = Context("when declarative healthchecks is turned on", func() {
 				Eventually(helpers.LRPStatePoller(lgr, bbsClient, processGuid, nil)).Should(Equal(models.ActualLRPStateRunning))
 				dlu := &models.DesiredLRPUpdate{}
 				dlu.SetInstances(2)
-				bbsClient.UpdateDesiredLRP(lgr, processGuid, dlu)
+				bbsClient.UpdateDesiredLRP(lgr, "", processGuid, dlu)
 			})
 
 			It("eventually runs", func() {

--- a/cell/lrp_test.go
+++ b/cell/lrp_test.go
@@ -112,7 +112,7 @@ var _ = Describe("LRP", func() {
 		})
 
 		JustBeforeEach(func() {
-			err := bbsClient.DesireLRP(lgr, lrp)
+			err := bbsClient.DesireLRP(lgr, "", lrp)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -275,7 +275,7 @@ var _ = Describe("LRP", func() {
 			It("passes them to garden", func() {
 				Eventually(helpers.LRPStatePoller(lgr, bbsClient, processGuid, nil)).Should(Equal(models.ActualLRPStateRunning))
 
-				lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid})
+				lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(lrps)).To(BeNumerically(">", 0))
 
@@ -344,7 +344,7 @@ var _ = Describe("LRP", func() {
 						"processGuid":   processGuid,
 						"updateRequest": desiredUpdate})
 
-					err := bbsClient.UpdateDesiredLRP(logger, processGuid, &desiredUpdate)
+					err := bbsClient.UpdateDesiredLRP(logger, "", processGuid, &desiredUpdate)
 
 					logger.Info("after-update-desired", lager.Data{
 						"error": err,
@@ -369,7 +369,7 @@ var _ = Describe("LRP", func() {
 
 			JustBeforeEach(func() {
 				Eventually(func() []*models.ActualLRP {
-					lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid})
+					lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 					Expect(err).NotTo(HaveOccurred())
 
 					return lrps
@@ -387,7 +387,7 @@ var _ = Describe("LRP", func() {
 				JustBeforeEach(func() {
 					dlu := &models.DesiredLRPUpdate{}
 					dlu.SetInstances(newInstances)
-					err := bbsClient.UpdateDesiredLRP(lgr, processGuid, dlu)
+					err := bbsClient.UpdateDesiredLRP(lgr, "", processGuid, dlu)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -398,7 +398,7 @@ var _ = Describe("LRP", func() {
 
 					It("scales up to the correct number of instances", func() {
 						Eventually(func() []*models.ActualLRP {
-							lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid})
+							lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 							Expect(err).NotTo(HaveOccurred())
 
 							return lrps
@@ -415,7 +415,7 @@ var _ = Describe("LRP", func() {
 
 					It("scales down to the correct number of instances", func() {
 						Eventually(func() []*models.ActualLRP {
-							lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid})
+							lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 							Expect(err).NotTo(HaveOccurred())
 
 							return lrps
@@ -432,7 +432,7 @@ var _ = Describe("LRP", func() {
 
 					It("scales down to the correct number of instances", func() {
 						Eventually(func() []*models.ActualLRP {
-							lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid})
+							lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 							Expect(err).NotTo(HaveOccurred())
 
 							return lrps
@@ -445,11 +445,11 @@ var _ = Describe("LRP", func() {
 						newInstances := int32(1)
 						dlu := &models.DesiredLRPUpdate{}
 						dlu.SetInstances(newInstances)
-						err := bbsClient.UpdateDesiredLRP(lgr, processGuid, dlu)
+						err := bbsClient.UpdateDesiredLRP(lgr, "", processGuid, dlu)
 						Expect(err).NotTo(HaveOccurred())
 
 						Eventually(func() []*models.ActualLRP {
-							lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid})
+							lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 							Expect(err).NotTo(HaveOccurred())
 
 							return lrps
@@ -462,13 +462,13 @@ var _ = Describe("LRP", func() {
 
 			Describe("deleting it", func() {
 				JustBeforeEach(func() {
-					err := bbsClient.RemoveDesiredLRP(lgr, processGuid)
+					err := bbsClient.RemoveDesiredLRP(lgr, "", processGuid)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("stops all instances", func() {
 					Eventually(func() []*models.ActualLRP {
-						lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid})
+						lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 						Expect(err).NotTo(HaveOccurred())
 
 						return lrps
@@ -545,7 +545,7 @@ var _ = Describe("LRP", func() {
 
 			It("fails and sets a placement error", func() {
 				lrpFunc := func() string {
-					lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid})
+					lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 					Expect(err).NotTo(HaveOccurred())
 					if len(lrps) == 0 {
 						return ""
@@ -564,7 +564,7 @@ var _ = Describe("LRP", func() {
 
 			It("fails and sets a placement error", func() {
 				lrpFunc := func() string {
-					lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid})
+					lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 					Expect(err).NotTo(HaveOccurred())
 					if len(lrps) == 0 {
 						return ""
@@ -586,7 +586,7 @@ var _ = Describe("LRP", func() {
 
 			It("runs", func() {
 				Eventually(func() []*models.ActualLRP {
-					lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid})
+					lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 					Expect(err).NotTo(HaveOccurred())
 					return lrps
 				}).Should(HaveLen(1))
@@ -602,7 +602,7 @@ var _ = Describe("LRP", func() {
 		crashCount := func(guid string, index int) func() int32 {
 			return func() int32 {
 				i := int32(index)
-				lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: guid, Index: &i})
+				lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: guid, Index: &i})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(lrps)).To(Equal(1))
 				return lrps[0].CrashCount
@@ -626,7 +626,7 @@ var _ = Describe("LRP", func() {
 				})
 
 				JustBeforeEach(func() {
-					err := bbsClient.DesireLRP(lgr, lrp)
+					err := bbsClient.DesireLRP(lgr, "", lrp)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -662,7 +662,7 @@ var _ = Describe("LRP", func() {
 				BeforeEach(func() {
 					lrp := helpers.DefaultLRPCreateRequest(componentMaker.Addresses(), processGuid, "log-guid", 1)
 
-					err := bbsClient.DesireLRP(lgr, lrp)
+					err := bbsClient.DesireLRP(lgr, "", lrp)
 					Expect(err).NotTo(HaveOccurred())
 
 					Eventually(helpers.LRPStatePoller(lgr, bbsClient, processGuid, nil)).Should(Equal(models.ActualLRPStateRunning))
@@ -671,7 +671,7 @@ var _ = Describe("LRP", func() {
 				JustBeforeEach(func() {
 					index := int32(0)
 					var err error
-					lrps, err = bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: processGuid, Index: &index})
+					lrps, err = bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid, Index: &index})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(len(lrps)).To(Equal(1))
 
@@ -717,7 +717,7 @@ var _ = Describe("LRP", func() {
 				Context("with invalid algorithm", func() {
 					It("eventually crashes", func() {
 						desireLRPWithChecksum("invalid_algorithm")
-						err := bbsClient.DesireLRP(lgr, lrp)
+						err := bbsClient.DesireLRP(lgr, "", lrp)
 						Expect(err).To(HaveOccurred())
 					})
 				})
@@ -727,7 +727,7 @@ var _ = Describe("LRP", func() {
 						BeforeEach(func() {
 							desireLRPWithChecksum("md5")
 
-							err := bbsClient.DesireLRP(lgr, lrp)
+							err := bbsClient.DesireLRP(lgr, "", lrp)
 							Expect(err).NotTo(HaveOccurred())
 						})
 
@@ -740,7 +740,7 @@ var _ = Describe("LRP", func() {
 						BeforeEach(func() {
 							desireLRPWithChecksum("sha1")
 
-							err := bbsClient.DesireLRP(lgr, lrp)
+							err := bbsClient.DesireLRP(lgr, "", lrp)
 							Expect(err).NotTo(HaveOccurred())
 						})
 
@@ -753,7 +753,7 @@ var _ = Describe("LRP", func() {
 						BeforeEach(func() {
 							desireLRPWithChecksum("sha256")
 
-							err := bbsClient.DesireLRP(lgr, lrp)
+							err := bbsClient.DesireLRP(lgr, "", lrp)
 							Expect(err).NotTo(HaveOccurred())
 						})
 
@@ -779,7 +779,7 @@ var _ = Describe("LRP", func() {
 				Context("with md5", func() {
 					BeforeEach(func() {
 						createDownloadActionChecksum("md5")
-						err := bbsClient.DesireLRP(lgr, lrp)
+						err := bbsClient.DesireLRP(lgr, "", lrp)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -791,7 +791,7 @@ var _ = Describe("LRP", func() {
 				Context("with sha1", func() {
 					BeforeEach(func() {
 						createDownloadActionChecksum("sha1")
-						err := bbsClient.DesireLRP(lgr, lrp)
+						err := bbsClient.DesireLRP(lgr, "", lrp)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -803,7 +803,7 @@ var _ = Describe("LRP", func() {
 				Context("with sha256", func() {
 					BeforeEach(func() {
 						createDownloadActionChecksum("sha256")
-						err := bbsClient.DesireLRP(lgr, lrp)
+						err := bbsClient.DesireLRP(lgr, "", lrp)
 						Expect(err).NotTo(HaveOccurred())
 					})
 

--- a/cell/network_env_test.go
+++ b/cell/network_env_test.go
@@ -68,12 +68,12 @@ var _ = Describe("Network Environment Variables", func() {
 			)
 			taskToDesire.ResultFile = "/home/vcap/env"
 
-			err := bbsClient.DesireTask(lgr, taskToDesire.TaskGuid, taskToDesire.Domain, taskToDesire.TaskDefinition)
+			err := bbsClient.DesireTask(lgr, "", taskToDesire.TaskGuid, taskToDesire.Domain, taskToDesire.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() interface{} {
 				var err error
-				task, err = bbsClient.TaskByGuid(lgr, guid)
+				task, err = bbsClient.TaskByGuid(lgr, "", guid)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				return task.State
@@ -113,13 +113,13 @@ var _ = Describe("Network Environment Variables", func() {
 				Env:  []*models.EnvironmentVariable{{Name: "PORT", Value: "8080"}},
 			})
 
-			err := bbsClient.DesireLRP(lgr, lrp)
+			err := bbsClient.DesireLRP(lgr, "", lrp)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(helpers.LRPStatePoller(lgr, bbsClient, guid, nil)).Should(Equal(models.ActualLRPStateRunning))
 			Eventually(helpers.ResponseCodeFromHostPoller(componentMaker.Addresses().Router, helpers.DefaultHost)).Should(Equal(http.StatusOK))
 
-			lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: guid})
+			lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: guid})
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(lrps).To(HaveLen(1))

--- a/cell/placement_tags_test.go
+++ b/cell/placement_tags_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Placement Tags", func() {
 	})
 
 	It("advertises placement tags in the cell presence", func() {
-		presences, err := bbsClient.Cells(lgr)
+		presences, err := bbsClient.Cells(lgr, "")
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(presences).To(HaveLen(1))
@@ -62,7 +62,7 @@ var _ = Describe("Placement Tags", func() {
 	})
 
 	It("advertises optional placement tags in the cell presence", func() {
-		presences, err := bbsClient.Cells(lgr)
+		presences, err := bbsClient.Cells(lgr, "")
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(presences).To(HaveLen(1))
@@ -73,7 +73,7 @@ var _ = Describe("Placement Tags", func() {
 		var lrp *models.DesiredLRP
 
 		JustBeforeEach(func() {
-			err := bbsClient.DesireLRP(lgr, lrp)
+			err := bbsClient.DesireLRP(lgr, "", lrp)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -84,7 +84,7 @@ var _ = Describe("Placement Tags", func() {
 
 			It("succeeds and is running on correct cell", func() {
 				lrpFunc := func() string {
-					lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: guid})
+					lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: guid})
 					Expect(err).NotTo(HaveOccurred())
 					if len(lrps) == 0 {
 						return ""
@@ -103,7 +103,7 @@ var _ = Describe("Placement Tags", func() {
 
 			It("succeeds and is running on correct cell", func() {
 				lrpFunc := func() string {
-					lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: guid})
+					lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: guid})
 					Expect(err).NotTo(HaveOccurred())
 					if len(lrps) == 0 {
 						return ""
@@ -122,7 +122,7 @@ var _ = Describe("Placement Tags", func() {
 
 			It("fails and sets a placement error", func() {
 				lrpFunc := func() string {
-					lrps, err := bbsClient.ActualLRPs(lgr, models.ActualLRPFilter{ProcessGuid: guid})
+					lrps, err := bbsClient.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: guid})
 					Expect(err).NotTo(HaveOccurred())
 					if len(lrps) == 0 {
 						return ""
@@ -170,7 +170,7 @@ var _ = Describe("Placement Tags", func() {
 		})
 
 		JustBeforeEach(func() {
-			err := bbsClient.DesireTask(lgr, task.TaskGuid, task.Domain, task.TaskDefinition)
+			err := bbsClient.DesireTask(lgr, "", task.TaskGuid, task.Domain, task.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -180,7 +180,7 @@ var _ = Describe("Placement Tags", func() {
 				Eventually(func() interface{} {
 					var err error
 
-					completedTask, err = bbsClient.TaskByGuid(lgr, guid)
+					completedTask, err = bbsClient.TaskByGuid(lgr, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return completedTask.State
@@ -213,7 +213,7 @@ var _ = Describe("Placement Tags", func() {
 
 			It("fails and sets a placement error", func() {
 				taskFunc := func() string {
-					t, err := bbsClient.TaskByGuid(lgr, task.TaskGuid)
+					t, err := bbsClient.TaskByGuid(lgr, "", task.TaskGuid)
 					Expect(err).NotTo(HaveOccurred())
 					return t.FailureReason
 				}

--- a/cell/privileges_test.go
+++ b/cell/privileges_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Privileges", func() {
 		})
 
 		JustBeforeEach(func() {
-			err := bbsClient.DesireTask(lgr, taskToDesire.TaskGuid, taskToDesire.Domain, taskToDesire.TaskDefinition)
+			err := bbsClient.DesireTask(lgr, "", taskToDesire.TaskGuid, taskToDesire.Domain, taskToDesire.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -106,7 +106,7 @@ var _ = Describe("Privileges", func() {
 		})
 
 		JustBeforeEach(func() {
-			err := bbsClient.DesireLRP(lgr, lrpRequest)
+			err := bbsClient.DesireLRP(lgr, "", lrpRequest)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(helpers.LRPStatePoller(lgr, bbsClient, lrpRequest.ProcessGuid, nil)).Should(Equal(models.ActualLRPStateRunning))
 		})

--- a/cell/secure_downloads_test.go
+++ b/cell/secure_downloads_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Secure Downloading and Uploading", func() {
 			tlsFileServer.StartTLS()
 
 			lrp = helpers.DefaultLRPCreateRequest(componentMaker.Addresses(), processGuid, "log-guid", 1)
-			err := bbsClient.DesireLRP(lgr, lrp)
+			err := bbsClient.DesireLRP(lgr, "", lrp)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -195,7 +195,7 @@ var _ = Describe("Secure Downloading and Uploading", func() {
 				),
 			)
 
-			err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+			err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(gotRequest).Should(BeClosed())

--- a/cell/ssh_test.go
+++ b/cell/ssh_test.go
@@ -165,11 +165,11 @@ var _ = Describe("SSH", func() {
 		logger := lagertest.NewTestLogger("test")
 		logger.Info("desired-ssh-lrp", lager.Data{"lrp": lrp})
 
-		err := bbsClient.DesireLRP(logger, &lrp)
+		err := bbsClient.DesireLRP(logger, "", &lrp)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() []*models.ActualLRP {
-			lrps, err := bbsClient.ActualLRPs(logger, models.ActualLRPFilter{ProcessGuid: processGuid})
+			lrps, err := bbsClient.ActualLRPs(logger, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 			Expect(err).NotTo(HaveOccurred())
 			return lrps
 		}).Should(HaveLen(2))

--- a/cell/task_as_user_test.go
+++ b/cell/task_as_user_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Tasks as specific user", func() {
 				},
 			)
 			expectedTask.Privileged = true
-			err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+			err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())
 
 			var task *models.Task
@@ -65,7 +65,7 @@ var _ = Describe("Tasks as specific user", func() {
 			Eventually(func() interface{} {
 				var err error
 
-				task, err = bbsClient.TaskByGuid(lgr, guid)
+				task, err = bbsClient.TaskByGuid(lgr, "", guid)
 				Expect(err).NotTo(HaveOccurred())
 
 				return task.State

--- a/cell/task_lifecycle_test.go
+++ b/cell/task_lifecycle_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Task Lifecycle", func() {
 			})
 
 			theFailureReason := func() string {
-				taskAfterCancel, err := bbsClient.TaskByGuid(lgr, taskGuid)
+				taskAfterCancel, err := bbsClient.TaskByGuid(lgr, "", taskGuid)
 				if err != nil {
 					return ""
 				}
@@ -117,7 +117,7 @@ var _ = Describe("Task Lifecycle", func() {
 			}
 
 			JustBeforeEach(func() {
-				err := bbsClient.DesireTask(lgr, taskToCreate.TaskGuid, taskToCreate.Domain, taskToCreate.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", taskToCreate.TaskGuid, taskToCreate.Domain, taskToCreate.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -174,12 +174,12 @@ var _ = Describe("Task Lifecycle", func() {
 				JustBeforeEach(func() {
 					Eventually(inigo_announcement_server.Announcements).Should(ContainElement(taskGuid))
 
-					err := bbsClient.CancelTask(lgr, taskGuid)
+					err := bbsClient.CancelTask(lgr, "", taskGuid)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("marks the task as complete, failed and cancelled", func() {
-					taskAfterCancel, err := bbsClient.TaskByGuid(lgr, taskGuid)
+					taskAfterCancel, err := bbsClient.TaskByGuid(lgr, "", taskGuid)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(taskAfterCancel.State).To(Equal(models.Task_Completed))
@@ -214,7 +214,7 @@ var _ = Describe("Task Lifecycle", func() {
 							Eventually(func() interface{} {
 								var err error
 
-								completedTask, err = bbsClient.TaskByGuid(lgr, taskGuid)
+								completedTask, err = bbsClient.TaskByGuid(lgr, "", taskGuid)
 								Expect(err).NotTo(HaveOccurred())
 
 								return completedTask.State
@@ -254,7 +254,7 @@ exit 0
 			})
 
 			JustBeforeEach(func() {
-				err := bbsClient.DesireTask(lgr, taskToCreate.TaskGuid, taskToCreate.Domain, taskToCreate.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", taskToCreate.TaskGuid, taskToCreate.Domain, taskToCreate.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -319,7 +319,7 @@ exit 0
 						Args: []string{inigo_announcement_server.AnnounceURL(taskGuid)},
 					},
 				)
-				err := bbsClient.DesireTask(lgr, taskToDesire.TaskGuid, taskToDesire.Domain, taskToDesire.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", taskToDesire.TaskGuid, taskToDesire.Domain, taskToDesire.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -364,7 +364,7 @@ exit 0
 					},
 				)
 
-				err := bbsClient.DesireTask(lgr, taskToDesire.TaskGuid, taskToDesire.Domain, taskToDesire.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", taskToDesire.TaskGuid, taskToDesire.Domain, taskToDesire.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -373,7 +373,7 @@ exit 0
 				Eventually(func() interface{} {
 					var err error
 
-					completedTask, err = bbsClient.TaskByGuid(lgr, taskGuid)
+					completedTask, err = bbsClient.TaskByGuid(lgr, "", taskGuid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return completedTask.State
@@ -393,7 +393,7 @@ func pollTaskStatus(taskGuid string, result string) {
 	Eventually(func() interface{} {
 		var err error
 
-		completedTask, err = bbsClient.TaskByGuid(lgr, taskGuid)
+		completedTask, err = bbsClient.TaskByGuid(lgr, "", taskGuid)
 		Expect(err).NotTo(HaveOccurred())
 
 		return completedTask.State

--- a/cell/task_test.go
+++ b/cell/task_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Tasks", func() {
 			)
 			expectedTask.Privileged = true
 
-			err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+			err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())
 
 			var task *models.Task
@@ -85,7 +85,7 @@ var _ = Describe("Tasks", func() {
 			Eventually(func() interface{} {
 				var err error
 
-				task, err = bbsClient.TaskByGuid(lgr, guid)
+				task, err = bbsClient.TaskByGuid(lgr, "", guid)
 				Expect(err).NotTo(HaveOccurred())
 
 				return task.State
@@ -106,7 +106,7 @@ var _ = Describe("Tasks", func() {
 			)
 			expectedTask.Privileged = true
 
-			err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+			err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 
 			Expect(err).NotTo(HaveOccurred())
 
@@ -115,7 +115,7 @@ var _ = Describe("Tasks", func() {
 			Eventually(func() interface{} {
 				var err error
 
-				task, err = bbsClient.TaskByGuid(lgr, guid)
+				task, err = bbsClient.TaskByGuid(lgr, "", guid)
 				Expect(err).NotTo(HaveOccurred())
 
 				return task.State
@@ -167,7 +167,7 @@ var _ = Describe("Tasks", func() {
 					},
 				}
 
-				err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 
 				var task *models.Task
@@ -175,7 +175,7 @@ var _ = Describe("Tasks", func() {
 				Eventually(func() interface{} {
 					var err error
 
-					task, err = bbsClient.TaskByGuid(lgr, guid)
+					task, err = bbsClient.TaskByGuid(lgr, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return task.State
@@ -205,7 +205,7 @@ var _ = Describe("Tasks", func() {
 				expectedTask.ImageUsername = privateUser
 				expectedTask.ImagePassword = privatePassword
 
-				err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 
 				var task *models.Task
@@ -213,7 +213,7 @@ var _ = Describe("Tasks", func() {
 				Eventually(func() interface{} {
 					var err error
 
-					task, err = bbsClient.TaskByGuid(lgr, guid)
+					task, err = bbsClient.TaskByGuid(lgr, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return task.State
@@ -266,7 +266,7 @@ var _ = Describe("Tasks", func() {
 					},
 				}
 
-				err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 
 				var task *models.Task
@@ -274,7 +274,7 @@ var _ = Describe("Tasks", func() {
 				Eventually(func() interface{} {
 					var err error
 
-					task, err = bbsClient.TaskByGuid(lgr, guid)
+					task, err = bbsClient.TaskByGuid(lgr, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return task.State
@@ -304,7 +304,7 @@ var _ = Describe("Tasks", func() {
 				expectedTask.ImageUsername = imageUsername
 				expectedTask.ImagePassword = imagePassword
 
-				err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 
 				var task *models.Task
@@ -312,7 +312,7 @@ var _ = Describe("Tasks", func() {
 				Eventually(func() interface{} {
 					var err error
 
-					task, err = bbsClient.TaskByGuid(lgr, guid)
+					task, err = bbsClient.TaskByGuid(lgr, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return task.State
@@ -347,7 +347,7 @@ var _ = Describe("Tasks", func() {
 					1024,
 				)
 
-				err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 
 				Expect(err).NotTo(HaveOccurred())
 
@@ -357,7 +357,7 @@ var _ = Describe("Tasks", func() {
 				Eventually(func() interface{} {
 					var err error
 
-					task, err = bbsClient.TaskByGuid(lgr, guid)
+					task, err = bbsClient.TaskByGuid(lgr, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return task.State
@@ -406,14 +406,14 @@ echo should have died by now
 					),
 				)
 
-				err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 
 				var task *models.Task
 				Eventually(func() interface{} {
 					var err error
 
-					task, err = bbsClient.TaskByGuid(lgr, guid)
+					task, err = bbsClient.TaskByGuid(lgr, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return task.State
@@ -456,7 +456,7 @@ echo should have died by now
 					),
 				)
 
-				err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 
 				Expect(err).NotTo(HaveOccurred())
 
@@ -464,7 +464,7 @@ echo should have died by now
 				Eventually(func() interface{} {
 					var err error
 
-					task, err = bbsClient.TaskByGuid(lgr, guid)
+					task, err = bbsClient.TaskByGuid(lgr, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return task.State
@@ -506,7 +506,7 @@ echo should have died by now
 					},
 				}
 
-				err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+				err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 
 				var properties garden.Properties
@@ -564,7 +564,7 @@ echo should have died by now
 
 			Context("with no checksum", func() {
 				It("downloads the file", func() {
-					err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+					err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 					Expect(err).NotTo(HaveOccurred())
 					Eventually(inigo_announcement_server.Announcements).Should(ContainElement(guid))
 				})
@@ -595,21 +595,21 @@ echo should have died by now
 
 					It("downloads the file for md5", func() {
 						createChecksum("md5")
-						err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+						err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 						Expect(err).NotTo(HaveOccurred())
 						Eventually(inigo_announcement_server.Announcements).Should(ContainElement(guid))
 					})
 
 					It("downloads the file for sha1", func() {
 						createChecksum("sha1")
-						err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+						err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 						Expect(err).NotTo(HaveOccurred())
 						Eventually(inigo_announcement_server.Announcements).Should(ContainElement(guid))
 					})
 
 					It("downloads the file for sha256", func() {
 						createChecksum("sha256")
-						err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+						err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 						Expect(err).NotTo(HaveOccurred())
 						Eventually(inigo_announcement_server.Announcements).Should(ContainElement(guid))
 					})
@@ -620,7 +620,7 @@ echo should have died by now
 					It("with incorrect algorithm", func() {
 						downloadAction.ChecksumAlgorithm = "incorrect_algorithm"
 						downloadAction.ChecksumValue = "incorrect_checksum"
-						err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+						err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 						Expect(err).To(HaveOccurred())
 					})
 
@@ -628,7 +628,7 @@ echo should have died by now
 						It("for md5", func() {
 							downloadAction.ChecksumAlgorithm = "md5"
 							downloadAction.ChecksumValue = "incorrect_checksum"
-							err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+							err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 							Expect(err).NotTo(HaveOccurred())
 							Eventually(helpers.TaskFailedPoller(lgr, bbsClient, expectedTask.TaskGuid, nil)).Should(BeTrue())
 						})
@@ -636,7 +636,7 @@ echo should have died by now
 						It("for sha1", func() {
 							downloadAction.ChecksumAlgorithm = "sha1"
 							downloadAction.ChecksumValue = "incorrect_checksum"
-							err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+							err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 							Expect(err).NotTo(HaveOccurred())
 							Eventually(helpers.TaskFailedPoller(lgr, bbsClient, expectedTask.TaskGuid, nil)).Should(BeTrue())
 						})
@@ -644,7 +644,7 @@ echo should have died by now
 						It("for sha256", func() {
 							downloadAction.ChecksumAlgorithm = "sha256"
 							downloadAction.ChecksumValue = "incorrect_checksum"
-							err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+							err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 							Expect(err).NotTo(HaveOccurred())
 							Eventually(helpers.TaskFailedPoller(lgr, bbsClient, expectedTask.TaskGuid, nil)).Should(BeTrue())
 						})
@@ -684,7 +684,7 @@ echo should have died by now
 
 			Context("with no checksum", func() {
 				It("downloads the file", func() {
-					err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+					err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 					Expect(err).NotTo(HaveOccurred())
 					Eventually(inigo_announcement_server.Announcements).Should(ContainElement(expectedTask.TaskGuid))
 				})
@@ -715,7 +715,7 @@ echo should have died by now
 
 					It("downloads the file for md5", func() {
 						createChecksum("md5")
-						err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+						err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 						Expect(err).NotTo(HaveOccurred())
 						expectedGuid := expectedTask.TaskGuid
 						Eventually(inigo_announcement_server.Announcements).Should(ContainElement(expectedGuid))
@@ -723,7 +723,7 @@ echo should have died by now
 
 					It("downloads the file for sha1", func() {
 						createChecksum("sha1")
-						err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+						err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 						Expect(err).NotTo(HaveOccurred())
 						expectedGuid := expectedTask.TaskGuid
 						Eventually(inigo_announcement_server.Announcements).Should(ContainElement(expectedGuid))
@@ -731,7 +731,7 @@ echo should have died by now
 
 					It("downloads the file for sha256", func() {
 						createChecksum("sha256")
-						err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+						err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 						Expect(err).NotTo(HaveOccurred())
 						expectedGuid := expectedTask.TaskGuid
 						Eventually(inigo_announcement_server.Announcements).Should(ContainElement(expectedGuid))
@@ -743,7 +743,7 @@ echo should have died by now
 					It("with incorrect algorithm", func() {
 						cachedDependency.ChecksumAlgorithm = "incorrect_algorithm"
 						cachedDependency.ChecksumValue = "incorrect_checksum"
-						err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+						err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 						Expect(err).To(HaveOccurred())
 					})
 
@@ -751,7 +751,7 @@ echo should have died by now
 						It("for md5", func() {
 							cachedDependency.ChecksumAlgorithm = "md5"
 							cachedDependency.ChecksumValue = "incorrect_checksum"
-							err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+							err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 							Expect(err).NotTo(HaveOccurred())
 							Eventually(helpers.TaskFailedPoller(lgr, bbsClient, expectedTask.TaskGuid, nil)).Should(BeTrue())
 						})
@@ -759,7 +759,7 @@ echo should have died by now
 						It("for sha1", func() {
 							cachedDependency.ChecksumAlgorithm = "sha1"
 							cachedDependency.ChecksumValue = "incorrect_checksum"
-							err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+							err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 							Expect(err).NotTo(HaveOccurred())
 							Eventually(helpers.TaskFailedPoller(lgr, bbsClient, expectedTask.TaskGuid, nil)).Should(BeTrue())
 						})
@@ -767,7 +767,7 @@ echo should have died by now
 						It("for sha256", func() {
 							cachedDependency.ChecksumAlgorithm = "sha256"
 							cachedDependency.ChecksumValue = "incorrect_checksum"
-							err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+							err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 							Expect(err).NotTo(HaveOccurred())
 							Eventually(helpers.TaskFailedPoller(lgr, bbsClient, expectedTask.TaskGuid, nil)).Should(BeTrue())
 						})
@@ -829,7 +829,7 @@ echo should have died by now
 				),
 			)
 
-			err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+			err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(gotRequest).Should(BeClosed())
@@ -852,14 +852,14 @@ echo should have died by now
 			)
 			expectedTask.ResultFile = "/home/vcap/thingy"
 
-			err := bbsClient.DesireTask(lgr, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+			err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())
 
 			var task *models.Task
 			Eventually(func() interface{} {
 				var err error
 
-				task, err = bbsClient.TaskByGuid(lgr, guid)
+				task, err = bbsClient.TaskByGuid(lgr, "", guid)
 				Expect(err).NotTo(HaveOccurred())
 
 				return task.State

--- a/cell/trace_id_test.go
+++ b/cell/trace_id_test.go
@@ -1,0 +1,76 @@
+package cell_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"code.cloudfoundry.org/archiver/extractor/test_helper"
+	"code.cloudfoundry.org/bbs/models"
+	"code.cloudfoundry.org/inigo/fixtures"
+	"code.cloudfoundry.org/inigo/helpers"
+	"code.cloudfoundry.org/lager/v3/lagertest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/tedsuo/ifrit"
+	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
+	"github.com/tedsuo/ifrit/grouper"
+)
+
+var _ = Describe("TraceId", func() {
+	var (
+		fileServerStaticDir string
+		fileServer          ifrit.Runner
+		ifritRuntime        ifrit.Process
+		lrp                 *models.DesiredLRP
+		testSink            *lagertest.TestSink
+		processGuid         string
+		rep                 *ginkgomon.Runner
+		auctioneer          *ginkgomon.Runner
+		router              *ginkgomon.Runner
+		routeEmitter        *ginkgomon.Runner
+		requestId           string
+		loggedRequestId     string
+	)
+
+	BeforeEach(func() {
+		requestId = "0bc29108-c522-4360-93dd-30ca38cce13d"
+		loggedRequestId = strings.ReplaceAll(requestId, "-", "")
+		fileServer, fileServerStaticDir = componentMaker.FileServer()
+		test_helper.CreateZipArchive(
+			filepath.Join(fileServerStaticDir, "lrp.zip"),
+			fixtures.GoServerApp(),
+		)
+		rep = componentMaker.Rep()
+		auctioneer = componentMaker.Auctioneer()
+		router = componentMaker.Router()
+		routeEmitter = componentMaker.RouteEmitter()
+		ifritRuntime = ginkgomon.Invoke(grouper.NewParallel(os.Kill, grouper.Members{
+			{Name: "rep", Runner: rep},
+			{Name: "auctioneer", Runner: auctioneer},
+			{Name: "router", Runner: router},
+			{Name: "route-emitter", Runner: routeEmitter},
+			{Name: "file-server", Runner: fileServer},
+		}))
+		processGuid = helpers.GenerateGuid()
+		lrp = helpers.DefaultLRPCreateRequest(componentMaker.Addresses(), processGuid, "log-guid", 1)
+		err := bbsClient.DesireLRP(lgr, requestId, lrp)
+		Expect(err).NotTo(HaveOccurred())
+		testSink = lagertest.NewTestSink()
+		lgr.RegisterSink(testSink)
+	})
+
+	AfterEach(func() {
+		helpers.StopProcesses(ifritRuntime)
+	})
+
+	It("logs request trace id", func() {
+		Eventually(helpers.LRPStatePoller(lgr, bbsClient, processGuid, nil)).Should(Equal(models.ActualLRPStateRunning))
+		Expect(bbsRunner).To(gbytes.Say(`"trace-id":"` + loggedRequestId + `"`))
+		Expect(auctioneer).To(gbytes.Say(`"trace-id":"` + loggedRequestId + `"`))
+		Expect(rep).To(gbytes.Say(`"trace-id":"` + loggedRequestId + `"`))
+		Expect(routeEmitter).To(gbytes.Say(`"trace-id":"` + loggedRequestId + `"`))
+		Expect(gardenRunner.Runner).To(gbytes.Say(`"trace-id":"` + loggedRequestId + `"`))
+	})
+})

--- a/executor/executor_garden_test.go
+++ b/executor/executor_garden_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Executor/Garden", func() {
 		container.Guid = generateGuid()
 
 		request := executor.NewAllocationRequest(container.Guid, &container.Resource, container.Tags)
-		failures := executorClient.AllocateContainers(logger, []executor.AllocationRequest{request})
+		failures := executorClient.AllocateContainers(logger, "", []executor.AllocationRequest{request})
 		Expect(failures).To(BeEmpty())
 
 		return request.Guid
@@ -376,7 +376,7 @@ var _ = Describe("Executor/Garden", func() {
 			})
 
 			JustBeforeEach(func() {
-				allocationFailures = executorClient.AllocateContainers(logger, []executor.AllocationRequest{allocationRequest})
+				allocationFailures = executorClient.AllocateContainers(logger, "", []executor.AllocationRequest{allocationRequest})
 			})
 
 			It("returns an empty error map", func() {
@@ -426,7 +426,7 @@ var _ = Describe("Executor/Garden", func() {
 
 			Context("when the guid is already taken", func() {
 				JustBeforeEach(func() {
-					allocationFailures = executorClient.AllocateContainers(logger, []executor.AllocationRequest{allocationRequest})
+					allocationFailures = executorClient.AllocateContainers(logger, "", []executor.AllocationRequest{allocationRequest})
 				})
 
 				It("returns an error", func() {
@@ -489,7 +489,7 @@ var _ = Describe("Executor/Garden", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					runReq = executor.NewRunRequest(guid, &runInfo, executor.Tags{})
-					runErr = executorClient.RunContainer(logger, &runReq)
+					runErr = executorClient.RunContainer(logger, "", &runReq)
 				})
 
 				AfterEach(func() {
@@ -671,7 +671,7 @@ var _ = Describe("Executor/Garden", func() {
 								go func() {
 									Eventually(containerStatePoller(guid)).Should(Equal(executor.StateCompleted))
 
-									err := executorClient.DeleteContainer(logger, guid)
+									err := executorClient.DeleteContainer(logger, "", guid)
 									Expect(err).NotTo(HaveOccurred())
 									close(done)
 								}()
@@ -735,7 +735,7 @@ var _ = Describe("Executor/Garden", func() {
 		Describe("running a bogus guid", func() {
 			It("returns an error", func() {
 				runReq := executor.NewRunRequest("bogus", &executor.RunInfo{}, executor.Tags{})
-				err := executorClient.RunContainer(logger, &runReq)
+				err := executorClient.RunContainer(logger, "", &runReq)
 				Expect(err).To(Equal(executor.ErrContainerNotFound))
 			})
 		})
@@ -754,7 +754,7 @@ var _ = Describe("Executor/Garden", func() {
 
 			Describe("deleting it", func() {
 				It("makes the previously allocated resources available again", func() {
-					err := executorClient.DeleteContainer(logger, guid)
+					err := executorClient.DeleteContainer(logger, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					Eventually(func() (executor.ExecutorResources, error) { return executorClient.RemainingResources(logger) }).Should(Equal(executor.ExecutorResources{
@@ -797,7 +797,7 @@ var _ = Describe("Executor/Garden", func() {
 					}),
 				}, executor.Tags{})
 
-				err := executorClient.RunContainer(logger, &runRequest)
+				err := executorClient.RunContainer(logger, "", &runRequest)
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(containerStatePoller(guid)).Should(Equal(executor.StateRunning))
@@ -805,12 +805,12 @@ var _ = Describe("Executor/Garden", func() {
 
 			Describe("StopContainer", func() {
 				It("does not return an error", func() {
-					err := executorClient.StopContainer(logger, guid)
+					err := executorClient.StopContainer(logger, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("stops the container but does not delete it", func() {
-					err := executorClient.StopContainer(logger, guid)
+					err := executorClient.StopContainer(logger, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					var container executor.Container
@@ -829,7 +829,7 @@ var _ = Describe("Executor/Garden", func() {
 
 			Describe("DeleteContainer", func() {
 				It("deletes the container", func() {
-					err := executorClient.DeleteContainer(logger, guid)
+					err := executorClient.DeleteContainer(logger, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					Eventually(func() error {
@@ -866,7 +866,7 @@ var _ = Describe("Executor/Garden", func() {
 						findGardenContainer(guid)
 
 						// delete it
-						err := executorClient.DeleteContainer(logger, guid)
+						err := executorClient.DeleteContainer(logger, "", guid)
 						Expect(err).NotTo(HaveOccurred())
 
 						Eventually(func() (executor.ExecutorResources, error) { return executorClient.RemainingResources(logger) }).Should(
@@ -935,7 +935,7 @@ var _ = Describe("Executor/Garden", func() {
 						}),
 					}, executor.Tags{})
 
-					err := executorClient.RunContainer(logger, &runRequest)
+					err := executorClient.RunContainer(logger, "", &runRequest)
 					Expect(err).NotTo(HaveOccurred())
 
 					container = findGardenContainer(guid)
@@ -969,7 +969,7 @@ var _ = Describe("Executor/Garden", func() {
 
 		Describe("pruning the registry", func() {
 			It("continously prunes the registry", func() {
-				failures := executorClient.AllocateContainers(logger, []executor.AllocationRequest{{
+				failures := executorClient.AllocateContainers(logger, "", []executor.AllocationRequest{{
 					Guid: "some-handle",
 					Resource: executor.Resource{
 						MemoryMB: 1024,
@@ -1043,7 +1043,7 @@ var _ = Describe("Executor/Garden", func() {
 						}),
 					}, executor.Tags{})
 
-					err := executorClient.RunContainer(logger, &runRequest)
+					err := executorClient.RunContainer(logger, "", &runRequest)
 					Expect(err).NotTo(HaveOccurred())
 
 					Eventually(containerStatePoller(guid)).Should(Equal(executor.StateRunning))

--- a/helpers/bbs_requests.go
+++ b/helpers/bbs_requests.go
@@ -63,7 +63,7 @@ var dockerMonitor = models.WrapAction(&models.RunAction{
 })
 
 func UpsertInigoDomain(logger lager.Logger, bbsClient bbs.InternalClient) {
-	err := bbsClient.UpsertDomain(logger, defaultDomain, 0)
+	err := bbsClient.UpsertDomain(logger, "", defaultDomain, 0)
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/helpers/pollers.go
+++ b/helpers/pollers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func filteredActualLRPs(logger lager.Logger, client bbs.InternalClient, processGuid string, filter func(lrp *models.ActualLRP) bool) []models.ActualLRP {
-	lrps, err := client.ActualLRPs(logger, models.ActualLRPFilter{ProcessGuid: processGuid})
+	lrps, err := client.ActualLRPs(logger, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 	Expect(err).NotTo(HaveOccurred())
 
 	startedLRPs := make([]models.ActualLRP, 0, len(lrps))
@@ -38,7 +38,7 @@ func RunningActualLRPs(logger lager.Logger, client bbs.InternalClient, processGu
 
 func TaskStatePoller(logger lager.Logger, client bbs.InternalClient, taskGuid string, task *models.Task) func() models.Task_State {
 	return func() models.Task_State {
-		rTask, err := client.TaskByGuid(logger, taskGuid)
+		rTask, err := client.TaskByGuid(logger, "", taskGuid)
 		Expect(err).NotTo(HaveOccurred())
 
 		if task != nil {
@@ -51,7 +51,7 @@ func TaskStatePoller(logger lager.Logger, client bbs.InternalClient, taskGuid st
 
 func TaskFailedPoller(logger lager.Logger, client bbs.InternalClient, taskGuid string, task *models.Task) func() bool {
 	return func() bool {
-		rTask, err := client.TaskByGuid(logger, taskGuid)
+		rTask, err := client.TaskByGuid(logger, "", taskGuid)
 		Expect(err).NotTo(HaveOccurred())
 
 		if task != nil {
@@ -66,9 +66,9 @@ func LRPStatePoller(logger lager.Logger, client bbs.InternalClient, processGuid 
 	return func() string {
 		var foundLRP *models.ActualLRP
 
-		lrps, err := client.ActualLRPs(logger, models.ActualLRPFilter{ProcessGuid: processGuid})
+		lrps, err := client.ActualLRPs(logger, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 		if err != nil && strings.Contains(err.Error(), "Invalid Response with status code: 404") {
-			lrpGroups, err := client.ActualLRPGroupsByProcessGuid(logger, processGuid)
+			lrpGroups, err := client.ActualLRPGroupsByProcessGuid(logger, "", processGuid)
 			Expect(err).NotTo(HaveOccurred())
 			if len(lrpGroups) == 0 {
 				return ""
@@ -93,9 +93,9 @@ func LRPInstanceStatePoller(logger lager.Logger, client bbs.InternalClient, proc
 	return func() string {
 		i := int32(index)
 		var foundLRP *models.ActualLRP
-		lrps, err := client.ActualLRPs(logger, models.ActualLRPFilter{ProcessGuid: processGuid, Index: &i})
+		lrps, err := client.ActualLRPs(logger, "", models.ActualLRPFilter{ProcessGuid: processGuid, Index: &i})
 		if err != nil && strings.Contains(err.Error(), "Invalid Response with status code: 404") {
-			lrpGroup, err := client.ActualLRPGroupByProcessGuidAndIndex(logger, processGuid, index)
+			lrpGroup, err := client.ActualLRPGroupByProcessGuidAndIndex(logger, "", processGuid, index)
 			Expect(err).NotTo(HaveOccurred())
 			foundLRP, _, err = lrpGroup.Resolve()
 			Expect(err).NotTo(HaveOccurred())

--- a/volman/volman_bbs_lrp_test.go
+++ b/volman/volman_bbs_lrp_test.go
@@ -128,7 +128,7 @@ var _ = Describe("LRPs with volume mounts", func() {
 		})
 
 		JustBeforeEach(func() {
-			err := bbsClient.DesireLRP(logger, lrp)
+			err := bbsClient.DesireLRP(logger, "", lrp)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -152,7 +152,7 @@ var _ = Describe("LRPs with volume mounts", func() {
 				var actualLRP *models.ActualLRP
 				Eventually(func() interface{} {
 					index := int32(0)
-					lrps, err := bbsClient.ActualLRPs(logger, models.ActualLRPFilter{ProcessGuid: processGuid, Index: &index})
+					lrps, err := bbsClient.ActualLRPs(logger, "", models.ActualLRPFilter{ProcessGuid: processGuid, Index: &index})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(len(lrps)).To(Equal(1))
 					Expect(lrps[0].Presence).NotTo(Equal(models.ActualLRP_Evacuating))
@@ -175,7 +175,7 @@ var _ = Describe("LRPs with volume mounts", func() {
 				var actualLRP *models.ActualLRP
 				Eventually(func() interface{} {
 					index := int32(0)
-					lrps, err := bbsClient.ActualLRPs(logger, models.ActualLRPFilter{ProcessGuid: processGuid, Index: &index})
+					lrps, err := bbsClient.ActualLRPs(logger, "", models.ActualLRPFilter{ProcessGuid: processGuid, Index: &index})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(len(lrps)).To(Equal(1))
 					Expect(lrps[0].Presence).NotTo(Equal(models.ActualLRP_Evacuating))
@@ -198,7 +198,7 @@ var _ = Describe("LRPs with volume mounts", func() {
 				var actualLRP *models.ActualLRP
 				Eventually(func() interface{} {
 					index := int32(0)
-					lrps, err := bbsClient.ActualLRPs(logger, models.ActualLRPFilter{ProcessGuid: processGuid, Index: &index})
+					lrps, err := bbsClient.ActualLRPs(logger, "", models.ActualLRPFilter{ProcessGuid: processGuid, Index: &index})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(lrps[0].Presence).NotTo(Equal(models.ActualLRP_Evacuating))
 					actualLRP = lrps[0]

--- a/volman/volman_bbs_task_test.go
+++ b/volman/volman_bbs_task_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Tasks", func() {
 				}
 				expectedTask.Privileged = true
 
-				err := bbsClient.DesireTask(logger, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+				err := bbsClient.DesireTask(logger, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -88,7 +88,7 @@ var _ = Describe("Tasks", func() {
 				Eventually(func() interface{} {
 					var err error
 
-					task, err = bbsClient.TaskByGuid(logger, guid)
+					task, err = bbsClient.TaskByGuid(logger, "", guid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return task.State
@@ -120,14 +120,14 @@ var _ = Describe("Tasks", func() {
 			})
 
 			It("should error placing the task", func() {
-				err := bbsClient.DesireTask(logger, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+				err := bbsClient.DesireTask(logger, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 
 				var task *models.Task
 				Eventually(func() interface{} {
 					var err error
 
-					task, err = bbsClient.TaskByGuid(logger, expectedTask.TaskGuid)
+					task, err = bbsClient.TaskByGuid(logger, "", expectedTask.TaskGuid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return task.State
@@ -163,14 +163,14 @@ var _ = Describe("Tasks", func() {
 			})
 
 			It("should error placing the task", func() {
-				err := bbsClient.DesireTask(logger, expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
+				err := bbsClient.DesireTask(logger, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
 
 				var task *models.Task
 				Eventually(func() interface{} {
 					var err error
 
-					task, err = bbsClient.TaskByGuid(logger, expectedTask.TaskGuid)
+					task, err = bbsClient.TaskByGuid(logger, "", expectedTask.TaskGuid)
 					Expect(err).NotTo(HaveOccurred())
 
 					return task.State

--- a/volman/volman_executor_test.go
+++ b/volman/volman_executor_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Executor/Garden/Volman", func() {
 
 				allocationRequest = executor.NewAllocationRequest(guid, &executor.Resource{}, tags)
 
-				allocationFailures = executorClient.AllocateContainers(logger, []executor.AllocationRequest{allocationRequest})
+				allocationFailures = executorClient.AllocateContainers(logger, "", []executor.AllocationRequest{allocationRequest})
 				Expect(allocationFailures).To(BeEmpty())
 			})
 
@@ -213,7 +213,7 @@ var _ = Describe("Executor/Garden/Volman", func() {
 				})
 
 				It("container start should succeed", func() {
-					err := executorClient.RunContainer(logger, &runReq)
+					err := executorClient.RunContainer(logger, "", &runReq)
 					Expect(err).NotTo(HaveOccurred())
 					Eventually(containerStatePoller(guid)).Should(Equal(executor.StateCompleted))
 					Expect(getContainer(guid).RunResult.Failed).Should(BeFalse())
@@ -263,7 +263,7 @@ var _ = Describe("Executor/Garden/Volman", func() {
 
 					allocationRequest = executor.NewAllocationRequest(guid, &executor.Resource{}, tags)
 
-					allocationFailures = executorClient.AllocateContainers(logger, []executor.AllocationRequest{allocationRequest})
+					allocationFailures = executorClient.AllocateContainers(logger, "", []executor.AllocationRequest{allocationRequest})
 					Expect(allocationFailures).To(BeEmpty())
 				})
 
@@ -297,14 +297,14 @@ var _ = Describe("Executor/Garden/Volman", func() {
 
 					Context("when successfully mounting a RW Mode volume", func() {
 						BeforeEach(func() {
-							err := executorClient.RunContainer(logger, &runReq)
+							err := executorClient.RunContainer(logger, "", &runReq)
 							Expect(err).NotTo(HaveOccurred())
 							Eventually(containerStatePoller(guid)).Should(Equal(executor.StateCompleted))
 							Expect(getContainer(guid).RunResult.Failed).Should(BeFalse())
 						})
 
 						AfterEach(func() {
-							err := executorClient.DeleteContainer(logger, guid)
+							err := executorClient.DeleteContainer(logger, "", guid)
 							Expect(err).NotTo(HaveOccurred())
 
 							err = os.RemoveAll(path.Join(componentMaker.VolmanDriverConfigDir(), "_volumes", volumeId))
@@ -338,7 +338,7 @@ var _ = Describe("Executor/Garden/Volman", func() {
 
 								tags := executor.Tags{"some-tag": "some-value"}
 								allocationRequest2 := executor.NewAllocationRequest(guid2, &executor.Resource{}, tags)
-								allocationFailures := executorClient.AllocateContainers(logger, []executor.AllocationRequest{allocationRequest2})
+								allocationFailures := executorClient.AllocateContainers(logger, "", []executor.AllocationRequest{allocationRequest2})
 								Expect(allocationFailures).To(BeEmpty())
 
 								fileName2 = fmt.Sprintf("testfile2-%d.txt", time.Now().UnixNano())
@@ -352,11 +352,11 @@ var _ = Describe("Executor/Garden/Volman", func() {
 									}),
 								}
 								runReq2 = executor.NewRunRequest(guid2, &runInfo, executor.Tags{})
-								err = executorClient.RunContainer(logger, &runReq2)
+								err = executorClient.RunContainer(logger, "", &runReq2)
 								Expect(err).NotTo(HaveOccurred())
 								Eventually(containerStatePoller(guid2)).Should(Equal(executor.StateCompleted))
 								Expect(getContainer(guid2).RunResult.Failed).Should(BeFalse())
-								err = executorClient.DeleteContainer(logger, guid2)
+								err = executorClient.DeleteContainer(logger, "", guid2)
 								Expect(err).NotTo(HaveOccurred())
 							})
 


### PR DESCRIPTION
to validate request id is logged as trace id in component logs

## Please provide the following information:

### What is this change about?

* Update all bbs client calls to take in trace ID
* Add trace_id_test.go that validates that component logs add request ID in their logs as trace-id

### What problem it is trying to solve?

Being able to trace the same request across multiple components.

### What is the impact if the change is not made?

Difficulty correlating actions happening in different components

### How should this change be described in diego-release release notes?

Add distributed tracing to Diego component logs

### Please provide any contextual information.

https://www.pivotaltracker.com/story/show/185075573

### Tag your pair, your PM, and/or team!

@reneighbor 

Thank you!
