### PR TITLE
GARDEN_ROOTFS -> GARDEN_TEST_ROOTFS

### DIFF
--- a/bin/test.bash
+++ b/bin/test.bash
@@ -77,11 +77,6 @@ setup_grootfs () {
     echo "iamgroot:1:4294967293" > /etc/subgid
   }
 
-build_garden_rootfs() {
-  tar cpf /tmp/rootfs.tar -C "$GARDEN_ROOTFS_FILES" .
-  export GARDEN_ROOTFS=/tmp/rootfs.tar
-}
-
 setup_diego_release() {
   pushd ${DIEGO_RELEASE_PATH}
 

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -77,7 +77,7 @@ echo "Log Dir: $logsDir"
 mkdir -Force "$logsDir"
 
 Setup-GardenRunc
-Configure-Groot "$env:GARDEN_ROOTFS"
+Configure-Groot "$env:GARDEN_TEST_ROOTFS"
 Configure-Winc-Network "delete"
 Configure-Winc-Network "create"
 Set-NetFirewallProfile -All -DefaultInboundAction Block -DefaultOutboundAction Allow -Enabled True

--- a/world/components.go
+++ b/world/components.go
@@ -183,7 +183,7 @@ func makeCommonComponentMaker(builtArtifacts BuiltArtifacts, worldAddresses Comp
 	grootfsBinPath := os.Getenv("GROOTFS_BINPATH")
 	grootfsStorePath := os.Getenv("GROOTFS_STORE_PATH")
 	gardenBinPath := os.Getenv("GARDEN_BINPATH")
-	gardenRootFSPath := os.Getenv("GARDEN_ROOTFS")
+	gardenRootFSPath := os.Getenv("GARDEN_TEST_ROOTFS")
 	gardenGraphPath := os.Getenv("GARDEN_GRAPH_PATH")
 
 	if gardenGraphPath == "" {
@@ -195,7 +195,7 @@ func makeCommonComponentMaker(builtArtifacts BuiltArtifacts, worldAddresses Comp
 		Expect(grootfsStorePath).NotTo(BeEmpty(), "must provide $GROOTFS_STORE_PATH")
 	}
 	Expect(gardenBinPath).NotTo(BeEmpty(), "must provide $GARDEN_BINPATH")
-	Expect(gardenRootFSPath).NotTo(BeEmpty(), "must provide $GARDEN_ROOTFS")
+	Expect(gardenRootFSPath).NotTo(BeEmpty(), "must provide $GARDEN_TEST_ROOTFS")
 
 	// tests depend on this env var to be set
 	externalAddress := os.Getenv("EXTERNAL_ADDRESS")


### PR DESCRIPTION
That's what we use in garden-runc-release, so let's keep convention