### PR TITLE
Use Server struct to address gosec G114

### DIFF
--- a/fixtures/go-server/server.go
+++ b/fixtures/go-server/server.go
@@ -47,8 +47,11 @@ func main() {
 		}
 		addr += ":" + port
 		go func(addr string) {
-			println(addr)
-			errCh <- http.ListenAndServe(addr, nil)
+			server := &http.Server{
+				Addr:    addr,
+				Handler: nil,
+			}
+			errCh <- server.ListenAndServe()
 		}(addr)
 	}
 
@@ -56,7 +59,11 @@ func main() {
 		go func() {
 			instanceCertPath := os.Getenv("CF_INSTANCE_CERT")
 			instanceKeyPath := os.Getenv("CF_INSTANCE_KEY")
-			errCh <- http.ListenAndServeTLS(":"+httpsPort, instanceCertPath, instanceKeyPath, nil)
+			server := &http.Server{
+				Addr:    fmt.Sprintf(":%s", httpsPort),
+				Handler: nil,
+			}
+			errCh <- server.ListenAndServeTLS(instanceCertPath, instanceKeyPath)
 		}()
 	}
 
@@ -73,7 +80,7 @@ func hello(res http.ResponseWriter, req *http.Request) {
 func write(res http.ResponseWriter, req *http.Request) {
 	mountPointPath := os.Getenv("MOUNT_POINT_DIR") + "/test.txt"
 
-	d1 := []byte("Hello Persistant World!\n")
+	d1 := []byte("Hello Persistent World!\n")
 	err := os.WriteFile(mountPointPath, d1, 0644)
 	if err != nil {
 		res.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
### What is this change about?

Using `Server` struct to create a server, which allows an option to specify a timeout

### What problem it is trying to solve?

To address gosec G114

### What is the impact if the change is not made?

No impact to behavior if change is not made

### How should this change be described in diego-release release notes?

Use `Server` struct, which allows setting a time out, to address gosec G114
