### PR TITLE
Fixing a typo

### DIFF
--- a/volman/volman_bbs_lrp_test.go
+++ b/volman/volman_bbs_lrp_test.go
@@ -137,7 +137,7 @@ var _ = Describe("LRPs with volume mounts", func() {
 			Eventually(helpers.HelloWorldInstancePoller(componentMaker.Addresses().Router, helpers.DefaultHost)).Should(ConsistOf([]string{"0"}))
 			body, statusCode, err := helpers.ResponseBodyAndStatusCodeFromHost(componentMaker.Addresses().Router, helpers.DefaultHost, "write")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(body)).To(Equal("Hello Persistant World!\n"))
+			Expect(string(body)).To(Equal("Hello Persistent World!\n"))
 			Expect(statusCode).To(Equal(200))
 		})
 


### PR DESCRIPTION
A typo was introduced in https://github.com/cloudfoundry/inigo/pull/37 which is causing tests to fail. Fixing the typo.