### PR TITLE
Fix error message for having too-many-files

### DIFF
--- a/cell/task_test.go
+++ b/cell/task_test.go
@@ -421,7 +421,7 @@ echo should have died by now
 
 				Expect(task.Failed).To(BeTrue())
 
-				Expect(task.FailureReason).To(ContainSubstring("LOG: Exited with status 2"))
+				Expect(task.FailureReason).To(ContainSubstring("too many open files"))
 			})
 		})
 


### PR DESCRIPTION
Bump in runc is giving us a different error msg

