### PR TITLE
Update the tests to match the new functionality

### DIFF
--- a/executor/executor_garden_test.go
+++ b/executor/executor_garden_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Executor/Garden", func() {
 		metronClient, err := loggingclient.NewIngressClient(loggingclient.Config{})
 		Expect(err).NotTo(HaveOccurred())
 
-		rootFSes := map[string]string{"somestack": gardenHealthcheckRootFS}
+		rootFSes := []string{gardenHealthcheckRootFS}
 
 		executorClient, _, executorMembers, err = executorinit.Initialize(logger, config, "", "", rootFSes, metronClient, clock.NewClock())
 		Expect(err).NotTo(HaveOccurred())
@@ -968,12 +968,14 @@ var _ = Describe("Executor/Garden", func() {
 
 		Describe("pruning the registry", func() {
 			It("continously prunes the registry", func() {
-				failures := executorClient.AllocateContainers(logger, "", []executor.AllocationRequest{{
-					Guid: "some-handle",
-					Resource: executor.Resource{
-						MemoryMB: 1024,
-						DiskMB:   1024,
-					}},
+				failures := executorClient.AllocateContainers(logger, "", []executor.AllocationRequest{
+					{
+						Guid: "some-handle",
+						Resource: executor.Resource{
+							MemoryMB: 1024,
+							DiskMB:   1024,
+						},
+					},
 				})
 				Expect(failures).To(BeEmpty())
 

--- a/volman/volman_executor_test.go
+++ b/volman/volman_executor_test.go
@@ -197,9 +197,7 @@ var _ = Describe("Executor/Garden/Volman", func() {
 			})
 
 			Context("when running the container", func() {
-				var (
-					runReq executor.RunRequest
-				)
+				var runReq executor.RunRequest
 
 				BeforeEach(func() {
 					runInfo := executor.RunInfo{
@@ -282,7 +280,7 @@ var _ = Describe("Executor/Garden/Volman", func() {
 						uniqueVolumeId := dockerdriverutils.NewVolumeId(volumeId, guid)
 						volumeDirectoryName = uniqueVolumeId.GetUniqueId()
 						someConfig := map[string]interface{}{"volume_id": volumeId}
-						volumeMounts = []executor.VolumeMount{executor.VolumeMount{ContainerPath: "/testmount", Driver: "localdriver", VolumeId: volumeId, Config: someConfig, Mode: executor.BindMountModeRW}}
+						volumeMounts = []executor.VolumeMount{{ContainerPath: "/testmount", Driver: "localdriver", VolumeId: volumeId, Config: someConfig, Mode: executor.BindMountModeRW}}
 						runInfo := executor.RunInfo{
 							VolumeMounts: volumeMounts,
 							Privileged:   true,
@@ -381,8 +379,8 @@ func initializeExecutor(logger lager.Logger, config executorinit.ExecutorConfig)
 	defaultRootFS := ""
 	metronClient, err := loggingclient.NewIngressClient(loggingclient.Config{})
 	Expect(err).NotTo(HaveOccurred())
-	rootFSes := map[string]string{
-		"somestack": defaultRootFS,
+	rootFSes := []string{
+		defaultRootFS,
 	}
 	executorClient, _, executorMembers, err = executorinit.Initialize(logger, config, "", "", rootFSes, metronClient, clock.NewClock())
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The PR makes sure the FSes are always used in a consistent way. The map was removed in favour of an array. The FSes should be stored in ascending order, ie. [ cflinuxfs3, cflinuxfs4 ]

The github issue: https://github.com/cloudfoundry/diego-release/issues/983

Backward Compatibility
---------------
Breaking Change? **No**
No breaking changes, just updating the tests to match the new functionality
