### PR TITLE
Adjust the tests per the new functionality

### DIFF
--- a/executor/executor_garden_test.go
+++ b/executor/executor_garden_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Executor/Garden", func() {
 
 		rootFSes := map[string]string{"somestack": gardenHealthcheckRootFS}
 
-		executorClient, _, executorMembers, err = executorinit.Initialize(logger, config, "", "", rootFSes, metronClient, clock.NewClock())
+		executorClient, _, executorMembers, err = executorinit.Initialize(logger, config, "", "", rootFSes, gardenHealthcheckRootFS, metronClient, clock.NewClock())
 		Expect(err).NotTo(HaveOccurred())
 		runner = grouper.NewParallel(os.Kill, executorMembers)
 
@@ -968,12 +968,14 @@ var _ = Describe("Executor/Garden", func() {
 
 		Describe("pruning the registry", func() {
 			It("continously prunes the registry", func() {
-				failures := executorClient.AllocateContainers(logger, "", []executor.AllocationRequest{{
-					Guid: "some-handle",
-					Resource: executor.Resource{
-						MemoryMB: 1024,
-						DiskMB:   1024,
-					}},
+				failures := executorClient.AllocateContainers(logger, "", []executor.AllocationRequest{
+					{
+						Guid: "some-handle",
+						Resource: executor.Resource{
+							MemoryMB: 1024,
+							DiskMB:   1024,
+						},
+					},
 				})
 				Expect(failures).To(BeEmpty())
 

--- a/volman/volman_executor_test.go
+++ b/volman/volman_executor_test.go
@@ -197,9 +197,7 @@ var _ = Describe("Executor/Garden/Volman", func() {
 			})
 
 			Context("when running the container", func() {
-				var (
-					runReq executor.RunRequest
-				)
+				var runReq executor.RunRequest
 
 				BeforeEach(func() {
 					runInfo := executor.RunInfo{
@@ -282,7 +280,7 @@ var _ = Describe("Executor/Garden/Volman", func() {
 						uniqueVolumeId := dockerdriverutils.NewVolumeId(volumeId, guid)
 						volumeDirectoryName = uniqueVolumeId.GetUniqueId()
 						someConfig := map[string]interface{}{"volume_id": volumeId}
-						volumeMounts = []executor.VolumeMount{executor.VolumeMount{ContainerPath: "/testmount", Driver: "localdriver", VolumeId: volumeId, Config: someConfig, Mode: executor.BindMountModeRW}}
+						volumeMounts = []executor.VolumeMount{{ContainerPath: "/testmount", Driver: "localdriver", VolumeId: volumeId, Config: someConfig, Mode: executor.BindMountModeRW}}
 						runInfo := executor.RunInfo{
 							VolumeMounts: volumeMounts,
 							Privileged:   true,
@@ -384,7 +382,7 @@ func initializeExecutor(logger lager.Logger, config executorinit.ExecutorConfig)
 	rootFSes := map[string]string{
 		"somestack": defaultRootFS,
 	}
-	executorClient, _, executorMembers, err = executorinit.Initialize(logger, config, "", "", rootFSes, metronClient, clock.NewClock())
+	executorClient, _, executorMembers, err = executorinit.Initialize(logger, config, "", "", rootFSes, defaultRootFS, metronClient, clock.NewClock())
 	Expect(err).NotTo(HaveOccurred())
 
 	return executorClient, grouper.NewParallel(os.Kill, executorMembers)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The PR makes sure the FSes are used in a consistent way. We have added a SidecarRootFS that will store the FS to be used for the envoy & healthchecks.

The github issue: https://github.com/cloudfoundry/diego-release/issues/983

Backward Compatibility
---------------
Breaking Change? **No**
No breaking changes, just updating tests to fit the new functionality
<!---