### PR TITLE
Use golang/protobuf instead of gogo/protobuf

### DIFF
--- a/cell/converger_test.go
+++ b/cell/converger_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Convergence to desired state", func() {
 
 				By("collecting the ActualLRP instance guids")
 				initialActuals := runningLRPsPoller()
-				initialInstanceGuids = []string{initialActuals[0].InstanceGuid, initialActuals[1].InstanceGuid}
+				initialInstanceGuids = []string{initialActuals[0].ActualLrpInstanceKey.InstanceGuid, initialActuals[1].ActualLrpInstanceKey.InstanceGuid}
 			})
 
 			It("marks the LRPs as Suspect until the rep comes back, and then marks the LRPs as Ordinary", func() {
@@ -120,7 +120,7 @@ var _ = Describe("Convergence to desired state", func() {
 
 				By("Asserting that the LRPs marked as Ordinary")
 				currentActuals := runningLRPsPoller()
-				instanceGuids := []string{currentActuals[0].InstanceGuid, currentActuals[1].InstanceGuid}
+				instanceGuids := []string{currentActuals[0].ActualLrpInstanceKey.InstanceGuid, currentActuals[1].ActualLrpInstanceKey.InstanceGuid}
 				Expect(instanceGuids).NotTo(ContainElement(initialInstanceGuids[0]))
 				Expect(instanceGuids).NotTo(ContainElement(initialInstanceGuids[1]))
 				Eventually(runningLRPsPresencePoller(models.ActualLRP_Ordinary)).Should(HaveLen(2))
@@ -152,8 +152,8 @@ var _ = Describe("Convergence to desired state", func() {
 						if len(secondActualLRPs) != 2 {
 							return false
 						}
-						return secondActualLRPs[0].CellId != firstActualLRPs[0].CellId &&
-							secondActualLRPs[1].CellId != firstActualLRPs[1].CellId
+						return secondActualLRPs[0].ActualLrpInstanceKey.CellId != firstActualLRPs[0].ActualLrpInstanceKey.CellId &&
+							secondActualLRPs[1].ActualLrpInstanceKey.CellId != firstActualLRPs[1].ActualLrpInstanceKey.CellId
 					}).Should(BeTrue())
 				})
 			})

--- a/cell/evacuation_test.go
+++ b/cell/evacuation_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Evacuation", func() {
 		var evacuatingRepPort uint16
 		var evacuatingRepRunner *ginkgomon.Runner
 
-		switch lrps[0].CellId {
+		switch lrps[0].ActualLrpInstanceKey.CellId {
 		case cellAID:
 			evacuatingRepRunner = cellARepRunner
 			evacuatingRepPort = cellPortsStart
@@ -232,7 +232,7 @@ var _ = Describe("Evacuation", func() {
 			// the following requests will hang since garden is stuck trying to destroy the containers
 			go func() {
 				for i := 0; i < 100; i++ {
-					err := client.StopLRPInstance(lgr, lrps[0].ActualLRPKey, lrps[0].ActualLRPInstanceKey)
+					err := client.StopLRPInstance(lgr, lrps[0].ActualLrpKey, lrps[0].ActualLrpInstanceKey)
 					if err != nil {
 						return
 					}

--- a/cell/instance_identity_test.go
+++ b/cell/instance_identity_test.go
@@ -735,7 +735,7 @@ var _ = Describe("InstanceIdentity", func() {
 					actualLRPs, err := bbsClient.ActualLRPs(logger, "", models.ActualLRPFilter{ProcessGuid: processGUID})
 					Expect(err).NotTo(HaveOccurred())
 					actualLRP := actualLRPs[0]
-					container, err = gardenClient.Lookup(actualLRP.InstanceGuid)
+					container, err = gardenClient.Lookup(actualLRP.ActualLrpInstanceKey.InstanceGuid)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -962,7 +962,7 @@ func getContainerInternalAddress(client bbs.Client, processGuid string, port uin
 	lrps, err := client.ActualLRPs(lgr, "", models.ActualLRPFilter{ProcessGuid: processGuid})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(lrps).To(HaveLen(1))
-	netInfo := lrps[0].ActualLRPNetInfo
+	netInfo := lrps[0].ActualLrpNetInfo
 	address := netInfo.InstanceAddress
 	for _, mapping := range netInfo.Ports {
 		if mapping.ContainerPort == port {
@@ -1006,7 +1006,7 @@ func runTaskAndGetCommandOutput(command string, organizationalUnits []string) st
 			OrganizationalUnit: organizationalUnits,
 		},
 	)
-	expectedTask.ResultFile = resultFile
+	expectedTask.TaskDefinition.ResultFile = resultFile
 
 	err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 	Expect(err).NotTo(HaveOccurred())

--- a/cell/local_route_emitter_test.go
+++ b/cell/local_route_emitter_test.go
@@ -260,7 +260,7 @@ var _ = Describe("LocalRouteEmitter", func() {
 				Context("to scale the app down", func() {
 					BeforeEach(func() {
 						newInstances := int32(1)
-						desiredLRPUdate.SetInstances(newInstances)
+						desiredLRPUdate.SetInstances(&newInstances)
 					})
 
 					It("eventually extra routes are removed within a second", func() {
@@ -311,7 +311,7 @@ var _ = Describe("LocalRouteEmitter", func() {
 
 			JustBeforeEach(func() {
 				dlu := &models.DesiredLRPUpdate{}
-				dlu.SetInstances(newInstances)
+				dlu.SetInstances(&newInstances)
 				err := bbsClient.UpdateDesiredLRP(lgr, "", processGuid, dlu)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -388,7 +388,7 @@ func evacuateARep(
 	Expect(lrps).To(HaveLen(3))
 	instancePerRepCount := map[string]int{}
 	for _, lrp := range lrps {
-		cellID := lrp.ActualLRPInstanceKey.CellId
+		cellID := lrp.ActualLrpInstanceKey.CellId
 		instancePerRepCount[cellID]++
 	}
 	repWithOneInstance := ""
@@ -438,7 +438,7 @@ func evacuateARep(
 		lrps := helpers.RunningActualLRPs(logger, bbsClient, processGuid)
 		cellIDs := map[string]int{}
 		for _, lrp := range lrps {
-			cellIDs[lrp.CellId]++
+			cellIDs[lrp.ActualLrpInstanceKey.CellId]++
 		}
 		return cellIDs
 	}).Should(Equal(map[string]int{otherRepID: 3}))

--- a/cell/long_running_healthchecks_test.go
+++ b/cell/long_running_healthchecks_test.go
@@ -176,7 +176,8 @@ var _ = Context("when declarative healthchecks is turned on", func() {
 			JustBeforeEach(func() {
 				Eventually(helpers.LRPStatePoller(lgr, bbsClient, processGuid, nil)).Should(Equal(models.ActualLRPStateRunning))
 				dlu := &models.DesiredLRPUpdate{}
-				dlu.SetInstances(2)
+				instances := int32(2)
+				dlu.SetInstances(&instances)
 				bbsClient.UpdateDesiredLRP(lgr, "", processGuid, dlu)
 			})
 

--- a/cell/lrp_test.go
+++ b/cell/lrp_test.go
@@ -278,7 +278,7 @@ var _ = Describe("LRP", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(lrps)).To(BeNumerically(">", 0))
 
-				containerHandle := lrps[0].InstanceGuid
+				containerHandle := lrps[0].ActualLrpInstanceKey.InstanceGuid
 
 				container, err := gardenClient.Lookup(containerHandle)
 				Expect(err).NotTo(HaveOccurred())
@@ -385,7 +385,7 @@ var _ = Describe("LRP", func() {
 
 				JustBeforeEach(func() {
 					dlu := &models.DesiredLRPUpdate{}
-					dlu.SetInstances(newInstances)
+					dlu.SetInstances(&newInstances)
 					err := bbsClient.UpdateDesiredLRP(lgr, "", processGuid, dlu)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -443,7 +443,7 @@ var _ = Describe("LRP", func() {
 					It("can be scaled back up", func() {
 						newInstances := int32(1)
 						dlu := &models.DesiredLRPUpdate{}
-						dlu.SetInstances(newInstances)
+						dlu.SetInstances(&newInstances)
 						err := bbsClient.UpdateDesiredLRP(lgr, "", processGuid, dlu)
 						Expect(err).NotTo(HaveOccurred())
 
@@ -674,7 +674,7 @@ var _ = Describe("LRP", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(len(lrps)).To(Equal(1))
 
-					err = gardenClient.Destroy(lrps[0].GetInstanceGuid())
+					err = gardenClient.Destroy(lrps[0].ActualLrpInstanceKey.InstanceGuid)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -686,8 +686,8 @@ var _ = Describe("LRP", func() {
 				It("contains the instance guid and cell id", func() {
 					Eventually(getEvents).Should(ContainElement(helpers.MatchActualLRPCrashedEvent(
 						processGuid,
-						lrps[0].InstanceGuid,
-						lrps[0].CellId,
+						lrps[0].ActualLrpInstanceKey.InstanceGuid,
+						lrps[0].ActualLrpInstanceKey.CellId,
 						0,
 					)))
 				})

--- a/cell/network_env_test.go
+++ b/cell/network_env_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Network Environment Variables", func() {
 					Args: []string{"-c", "/usr/bin/env | grep 'CF_INSTANCE' > /home/vcap/env"},
 				},
 			)
-			taskToDesire.ResultFile = "/home/vcap/env"
+			taskToDesire.TaskDefinition.ResultFile = "/home/vcap/env"
 
 			err := bbsClient.DesireTask(lgr, "", taskToDesire.TaskGuid, taskToDesire.Domain, taskToDesire.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())
@@ -132,7 +132,7 @@ var _ = Describe("Network Environment Variables", func() {
 		})
 
 		It("sets the networking environment variables", func() {
-			netInfo := actualLRP.ActualLRPNetInfo
+			netInfo := actualLRP.ActualLrpNetInfo
 			Expect(response).To(ContainSubstring(fmt.Sprintf("CF_INSTANCE_ADDR=%s:%d\n", netInfo.Address, netInfo.Ports[0].HostPort)))
 			Expect(response).To(ContainSubstring(fmt.Sprintf("CF_INSTANCE_IP=%s\n", os.Getenv("EXTERNAL_ADDRESS"))))
 			Expect(response).To(ContainSubstring(fmt.Sprintf("CF_INSTANCE_INTERNAL_IP=%s\n", netInfo.InstanceAddress)))

--- a/cell/placement_tags_test.go
+++ b/cell/placement_tags_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Placement Tags", func() {
 					if len(lrps) == 0 {
 						return ""
 					}
-					return lrps[0].CellId
+					return lrps[0].ActualLrpInstanceKey.CellId
 				}
 				Eventually(lrpFunc).Should(MatchRegexp("the-cell-id-.*-0"))
 				Eventually(helpers.LRPStatePoller(lgr, bbsClient, guid, nil)).Should(Equal(models.ActualLRPStateRunning))
@@ -108,7 +108,7 @@ var _ = Describe("Placement Tags", func() {
 					if len(lrps) == 0 {
 						return ""
 					}
-					return lrps[0].CellId
+					return lrps[0].ActualLrpInstanceKey.CellId
 				}
 				Eventually(lrpFunc).Should(MatchRegexp("the-cell-id-.*-0"))
 				Eventually(helpers.LRPStatePoller(lgr, bbsClient, guid, nil)).Should(Equal(models.ActualLRPStateRunning))
@@ -127,7 +127,7 @@ var _ = Describe("Placement Tags", func() {
 					if len(lrps) == 0 {
 						return ""
 					}
-					lgr.Info("lrp-cell-id", lager.Data{"cell-id": lrps[0].CellId})
+					lgr.Info("lrp-cell-id", lager.Data{"cell-id": lrps[0].ActualLrpInstanceKey.CellId})
 
 					return lrps[0].PlacementError
 				}

--- a/cell/privileges_test.go
+++ b/cell/privileges_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Privileges", func() {
 
 		Context("when the task is privileged", func() {
 			BeforeEach(func() {
-				taskToDesire.Privileged = true
+				taskToDesire.TaskDefinition.Privileged = true
 			})
 
 			It("succeeds", func() {
@@ -82,7 +82,7 @@ var _ = Describe("Privileges", func() {
 
 		Context("when the task is not privileged", func() {
 			BeforeEach(func() {
-				taskToDesire.Privileged = false
+				taskToDesire.TaskDefinition.Privileged = false
 			})
 
 			It("fails", func() {

--- a/cell/task_as_user_test.go
+++ b/cell/task_as_user_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Tasks as specific user", func() {
 					Args: []string{"-c", `[ $(whoami) = testuser ]`},
 				},
 			)
-			expectedTask.Privileged = true
+			expectedTask.TaskDefinition.Privileged = true
 			err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/cell/task_lifecycle_test.go
+++ b/cell/task_lifecycle_test.go
@@ -250,7 +250,7 @@ exit 0
 						},
 					},
 				)
-				taskToCreate.ResultFile = "/tmp/result"
+				taskToCreate.TaskDefinition.ResultFile = "/tmp/result"
 			})
 
 			JustBeforeEach(func() {
@@ -267,7 +267,7 @@ exit 0
 
 			Context("with appropriate security group setting", func() {
 				BeforeEach(func() {
-					taskToCreate.EgressRules = []*models.SecurityGroupRule{
+					taskToCreate.TaskDefinition.EgressRules = []*models.SecurityGroupRule{
 						{
 							Protocol:     models.TCPProtocol,
 							Destinations: []string{"9.0.0.0-89.255.255.255", "90.0.0.0-94.0.0.0"},

--- a/cell/task_test.go
+++ b/cell/task_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Tasks", func() {
 					},
 				},
 			)
-			expectedTask.Privileged = true
+			expectedTask.TaskDefinition.Privileged = true
 
 			err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())
@@ -104,7 +104,7 @@ var _ = Describe("Tasks", func() {
 					Dir:  "/tmp",
 				},
 			)
-			expectedTask.Privileged = true
+			expectedTask.TaskDefinition.Privileged = true
 
 			err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 
@@ -150,16 +150,16 @@ var _ = Describe("Tasks", func() {
 						Args: []string{"--dockerRef", privateRef, "--dockerUser", privateUser, "--dockerPassword", privatePassword, "--outputMetadataJSONFilename", "/tmp/result.json"},
 					},
 				)
-				expectedTask.CachedDependencies = []*models.CachedDependency{{
+				expectedTask.TaskDefinition.CachedDependencies = []*models.CachedDependency{{
 					From:      fmt.Sprintf("http://%s/v1/static/docker_app_lifecycle/docker_app_lifecycle.tgz", componentMaker.Addresses().FileServer),
 					To:        "/tmp/diego/dockerapplifecycle",
 					Name:      "docker app lifecycle",
 					CacheKey:  "docker-app-lifecycle",
 					LogSource: "docker-app-lifecycle",
 				}}
-				expectedTask.Privileged = true
-				expectedTask.ResultFile = "/tmp/result.json"
-				expectedTask.EgressRules = []*models.SecurityGroupRule{
+				expectedTask.TaskDefinition.Privileged = true
+				expectedTask.TaskDefinition.ResultFile = "/tmp/result.json"
+				expectedTask.TaskDefinition.EgressRules = []*models.SecurityGroupRule{
 					{
 						// allow traffic to the docker registry
 						Protocol:     models.AllProtocol,
@@ -200,10 +200,10 @@ var _ = Describe("Tasks", func() {
 						},
 					},
 				)
-				expectedTask.Privileged = true
-				expectedTask.RootFs = privateDockerRootFSPath
-				expectedTask.ImageUsername = privateUser
-				expectedTask.ImagePassword = privatePassword
+				expectedTask.TaskDefinition.Privileged = true
+				expectedTask.TaskDefinition.RootFs = privateDockerRootFSPath
+				expectedTask.TaskDefinition.ImageUsername = privateUser
+				expectedTask.TaskDefinition.ImagePassword = privatePassword
 
 				err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
@@ -249,16 +249,16 @@ var _ = Describe("Tasks", func() {
 						Args: []string{"--dockerRef", imageRef, "--dockerUser", imageUsername, "--dockerPassword", imagePassword, "--outputMetadataJSONFilename", "/tmp/result.json"},
 					},
 				)
-				expectedTask.CachedDependencies = []*models.CachedDependency{{
+				expectedTask.TaskDefinition.CachedDependencies = []*models.CachedDependency{{
 					From:      fmt.Sprintf("http://%s/v1/static/docker_app_lifecycle/docker_app_lifecycle.tgz", componentMaker.Addresses().FileServer),
 					To:        "/tmp/diego/dockerapplifecycle",
 					Name:      "docker app lifecycle",
 					CacheKey:  "docker-app-lifecycle",
 					LogSource: "docker-app-lifecycle",
 				}}
-				expectedTask.Privileged = true
-				expectedTask.ResultFile = "/tmp/result.json"
-				expectedTask.EgressRules = []*models.SecurityGroupRule{
+				expectedTask.TaskDefinition.Privileged = true
+				expectedTask.TaskDefinition.ResultFile = "/tmp/result.json"
+				expectedTask.TaskDefinition.EgressRules = []*models.SecurityGroupRule{
 					{
 						// allow traffic to the docker registry
 						Protocol:     models.AllProtocol,
@@ -299,10 +299,10 @@ var _ = Describe("Tasks", func() {
 						},
 					},
 				)
-				expectedTask.Privileged = true
-				expectedTask.RootFs = imageRootFSPath
-				expectedTask.ImageUsername = imageUsername
-				expectedTask.ImagePassword = imagePassword
+				expectedTask.TaskDefinition.Privileged = true
+				expectedTask.TaskDefinition.RootFs = imageRootFSPath
+				expectedTask.TaskDefinition.ImageUsername = imageUsername
+				expectedTask.TaskDefinition.ImagePassword = imagePassword
 
 				err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
@@ -375,7 +375,7 @@ var _ = Describe("Tasks", func() {
 				nofile := uint64(10)
 
 				rl := &models.ResourceLimits{}
-				rl.SetNofile(nofile)
+				rl.SetNofile(&nofile)
 
 				expectedTask := helpers.TaskCreateRequest(
 					guid,
@@ -500,7 +500,7 @@ echo should have died by now
 						},
 					},
 				)
-				expectedTask.Network = &models.Network{
+				expectedTask.TaskDefinition.Network = &models.Network{
 					Properties: map[string]string{
 						"some-key": "some-value",
 					},
@@ -675,11 +675,11 @@ echo should have died by now
 					},
 				)
 
-				expectedTask.CachedDependencies = []*models.CachedDependency{
+				expectedTask.TaskDefinition.CachedDependencies = []*models.CachedDependency{
 					cachedDependency,
 				}
 
-				expectedTask.Privileged = true
+				expectedTask.TaskDefinition.Privileged = true
 			})
 
 			Context("with no checksum", func() {
@@ -850,7 +850,7 @@ echo should have died by now
 					Args: []string{"-c", "echo tasty thingy > thingy"},
 				},
 			)
-			expectedTask.ResultFile = "/home/vcap/thingy"
+			expectedTask.TaskDefinition.ResultFile = "/home/vcap/thingy"
 
 			err := bbsClient.DesireTask(lgr, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 			Expect(err).NotTo(HaveOccurred())

--- a/helpers/bbs_requests.go
+++ b/helpers/bbs_requests.go
@@ -158,7 +158,7 @@ func TaskCreateRequest(taskGuid string, action models.ActionInterface) *models.T
 
 func TaskCreateRequestWithTags(taskGuid string, action models.ActionInterface, tags []string) *models.Task {
 	task := taskCreateRequest(taskGuid, defaultPreloadedRootFS, action, 0, 0, nil)
-	task.PlacementTags = tags
+	task.TaskDefinition.PlacementTags = tags
 	return task
 }
 

--- a/helpers/match_bbs_event.go
+++ b/helpers/match_bbs_event.go
@@ -31,10 +31,10 @@ func (matcher *ActualLRPCrashedEventMatcher) Match(actual interface{}) (success 
 	if !ok {
 		return false, nil
 	}
-	return event.ProcessGuid == matcher.ProcessGuid &&
-		event.Index == int32(matcher.Index) &&
-		event.CellId == matcher.CellId &&
-		event.InstanceGuid == matcher.InstanceGuid, nil
+	return event.ActualLrpKey.ProcessGuid == matcher.ProcessGuid &&
+		event.ActualLrpKey.Index == int32(matcher.Index) &&
+		event.ActualLrpInstanceKey.CellId == matcher.CellId &&
+		event.ActualLrpInstanceKey.InstanceGuid == matcher.InstanceGuid, nil
 }
 
 func (matcher *ActualLRPCrashedEventMatcher) FailureMessage(actual interface{}) (message string) {

--- a/volman/volman_bbs_task_test.go
+++ b/volman/volman_bbs_task_test.go
@@ -74,10 +74,10 @@ var _ = Describe("Tasks", func() {
 						Args: []string{"/testmount/" + fileName},
 					},
 				)
-				expectedTask.VolumeMounts = []*models.VolumeMount{
+				expectedTask.TaskDefinition.VolumeMounts = []*models.VolumeMount{
 					generateVolumeObject("localdriver"),
 				}
-				expectedTask.Privileged = true
+				expectedTask.TaskDefinition.Privileged = true
 
 				err := bbsClient.DesireTask(logger, "", expectedTask.TaskGuid, expectedTask.Domain, expectedTask.TaskDefinition)
 				Expect(err).NotTo(HaveOccurred())
@@ -113,10 +113,10 @@ var _ = Describe("Tasks", func() {
 						Args: []string{"-c", "echo 'volman!'"},
 					},
 				)
-				expectedTask.VolumeMounts = []*models.VolumeMount{
+				expectedTask.TaskDefinition.VolumeMounts = []*models.VolumeMount{
 					generateVolumeObject("non-existent-driver"),
 				}
-				expectedTask.Privileged = true
+				expectedTask.TaskDefinition.Privileged = true
 			})
 
 			It("should error placing the task", func() {
@@ -154,12 +154,12 @@ var _ = Describe("Tasks", func() {
 					},
 				)
 
-				expectedTask.VolumeMounts = []*models.VolumeMount{
+				expectedTask.TaskDefinition.VolumeMounts = []*models.VolumeMount{
 					generateVolumeObject("non-existent-driver"),
 					generateVolumeObject("localdriver"),
 				}
 
-				expectedTask.Privileged = true
+				expectedTask.TaskDefinition.Privileged = true
 			})
 
 			It("should error placing the task", func() {

--- a/world/components.go
+++ b/world/components.go
@@ -730,7 +730,7 @@ func (maker commonComponentMaker) RoutingAPI(modifyConfigFuncs ...func(*routinga
 		}
 	})
 
-	runner, err := routingapi.NewRoutingAPIRunner(binPath, int(port+1), sqlConfig, modifyConfigFuncs...)
+	runner, err := routingapi.NewRoutingAPIRunner(binPath, port+1, sqlConfig, modifyConfigFuncs...)
 	Expect(err).NotTo(HaveOccurred())
 	return runner
 }


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
[gogo/protobuf](https://github.com/gogo/protobuf) has been deprecated for years.  We should be using up-to-date protobufs provided by [google.golang.org/protobuf](https://github.com/protocolbuffers/protobuf-go).  In order to fit our use cases, a protobuf plugin (`protoc-gen-go-bbs`) has been created to catch any customizations we want to add.


Backward Compatibility
---------------
Breaking Change? **No**
