### PR TITLE
Set DeclarativeHealthCheckDefaultTimeout, fixing the tests

### DIFF
--- a/cell/instance_identity_test.go
+++ b/cell/instance_identity_test.go
@@ -868,6 +868,7 @@ var _ = Describe("InstanceIdentity", func() {
 
 				enableDeclarativeHealthChecks := func(config *config.RepConfig) {
 					config.EnableDeclarativeHealthcheck = true
+					config.DeclarativeHealthCheckDefaultTimeout = durationjson.Duration(1 * time.Second)
 					config.DeclarativeHealthcheckPath = componentMaker.Artifacts().Healthcheck
 					config.HealthCheckWorkPoolSize = 1
 				}

--- a/cell/long_running_healthchecks_test.go
+++ b/cell/long_running_healthchecks_test.go
@@ -53,6 +53,7 @@ var _ = Context("when declarative healthchecks is turned on", func() {
 
 		turnOnLongRunningHealthchecks := func(cfg *config.RepConfig) {
 			cfg.EnableDeclarativeHealthcheck = true
+			cfg.DeclarativeHealthCheckDefaultTimeout = durationjson.Duration(1 * time.Second)
 			cfg.DeclarativeHealthcheckPath = componentMaker.Artifacts().Healthcheck
 			cfg.HealthCheckWorkPoolSize = 1
 		}


### PR DESCRIPTION
### What problem it is trying to solve?

Following the changes to the executor, when declarative healtcheck is enabled, a timeout property is required to be set. There is default value of 1s in the rep's spec, but the validation fails when the config object is created in the tests.

### What is the impact if the change is not made?

Tests failing

### How should this change be described in diego-release release notes?

Set DeclarativeHealthCheckDefaultTimeout in inigo tests

### Please provide any contextual information.

https://github.com/cloudfoundry/diego-release/issues/1013
